### PR TITLE
Fixed corrupted ZIP attachments

### DIFF
--- a/ImapMailbox.php
+++ b/ImapMailbox.php
@@ -156,7 +156,7 @@ class ImapMailbox {
 		elseif($partStruct->encoding == 4) {
 			$data = $this->imap_qprint($data);
 		}
-		$data = trim($data);
+		//$data = trim($data); //this damages zip attachments
 
 		$params = array();
 		if(!empty($partStruct->parameters)) {


### PR DESCRIPTION
Hi, I have fixed the bug in your code.
When I tried to use it for getting of ZIP attachments, some of them ended up with whitespaces which were trimmed by the code. This resulted in a corrupted ZIP attachments being downloaded.
