### PR TITLE
Exposing attachment data

### DIFF
--- a/src/ImapMailbox.php
+++ b/src/ImapMailbox.php
@@ -572,6 +572,7 @@ class IncomingMailAttachment {
 	public $name;
 	public $filePath;
 	public $raw_decoded;
+	public $mime_type;
 	public $struct_types = array(
 		'text',
 		'multipart',


### PR DESCRIPTION
Exposing the raw_decoded attachments and their types is preferable to writing them to a directory. Use case: Forwarding imap mails with their attachments.
