### PR TITLE
getMailsInfo improvements + added mailboxes attributes 

### DIFF
--- a/src/ImapMailbox.php
+++ b/src/ImapMailbox.php
@@ -267,8 +267,8 @@ class ImapMailbox {
         {
             foreach($mails as &$mail)
             {
-                if(isset($mails[$id]->subject)) $mails[$id]->subject = $this->decodeMimeStr($mail->subject, $this->serverEncoding);
-                if(isset($mails[$id]->from)) $mails[$id]->from = $this->decodeMimeStr($mail->from, $this->serverEncoding);
+                if(isset($mail->subject)) $mail->subject = $this->decodeMimeStr($mail->subject, $this->serverEncoding);
+                if(isset($mail->from)) $mail->from = $this->decodeMimeStr($mail->from, $this->serverEncoding);
                 if(isset($mail->to)) $mail->to = $this->decodeMimeStr($mail->to, $this->serverEncoding);
             }
         }


### PR DESCRIPTION
**getMailsInfo bug fix : add some if statements**
I'm developing a webmail for a customer and I found a mail without "to" and "subject".

**added mailboxes attributes**
It's very useful when you use imap_getmailboxes()
Tomorrow I will implement this function with a optional $tree parameter that will automatically sorts folders on a tree. 

Here an example of what we can do with these attributes (Yeah, I need to learn a better way to play with binaries): 

``` php
    function decomposeAttributes($attributes)
    {
        $bin = decbin($attributes);
        $setAttribute = array();

        if ($bin >=1000000){
            $setAttribute[] = ImapMailbox::LATT_HASNOCHILDREN;
            $bin = $bin-1000000;
        }

        if ($bin >=100000){
            $setAttribute[] = ImapMailbox::LATT_HASCHILDREN;
            $bin = $bin-100000;
        }

        if ($bin >=10000){
            $setAttribute[] = ImapMailbox::LATT_REFERRAL;
            $bin = $bin-10000;
        }

        if ($bin >=1000){
            $setAttribute[] = ImapMailbox::LATT_UNMARKED;
            $bin = $bin-1000;
        }

        if ($bin >=100){
            $setAttribute[] = ImapMailbox::LATT_MARKED;
            $bin = $bin-100;
        }

        if ($bin >=10){
            $setAttribute[] = ImapMailbox::LATT_NOSELECT;
            $bin = $bin-10;
        }

        if ($bin >=1){
            $setAttribute[] = ImapMailbox::LATT_NOINFERIORS;
            $bin = $bin-1;
        }

        return $setAttribute;
    }
```

Inspired by http://www.php.net/manual/en/function.imap-getmailboxes.php
