### PR TITLE
Test if subject property is set

### DIFF
--- a/src/ImapMailbox.php
+++ b/src/ImapMailbox.php
@@ -372,7 +372,7 @@ class ImapMailbox {
 		$mail = new IncomingMail();
 		$mail->id = $mailId;
 		$mail->date = date('Y-m-d H:i:s', isset($head->date) ? strtotime($head->date) : time());
-		$mail->subject = $this->decodeMimeStr($head->subject, $this->serverEncoding);
+		$mail->subject = isset($head->subject) ? $this->decodeMimeStr($head->subject, $this->serverEncoding) : null;
 		$mail->fromName = isset($head->from[0]->personal) ? $this->decodeMimeStr($head->from[0]->personal, $this->serverEncoding) : null;
 		$mail->fromAddress = strtolower($head->from[0]->mailbox . '@' . $head->from[0]->host);
 


### PR DESCRIPTION
If an email is sent without a subject line, the script throws `Undefined property: stdClass::$subject. In /ImapMailbox.php, line 367` and won't continue to the next email. Adding an isset() check for $head->subject fixes the problem.
