### PR TITLE
Changed isUrlEncoded, to handle weird attachment names

### DIFF
--- a/src/ImapMailbox.php
+++ b/src/ImapMailbox.php
@@ -538,9 +538,9 @@ class ImapMailbox {
 	}
 
 	function isUrlEncoded($string) {
-		$string = str_replace('%20', '+', $string);
-		$decoded = urldecode($string);
-		return $decoded != $string && urlencode($decoded) == $string;
+		$hasInvalidChars = preg_match( '#[^%a-zA-Z0-9\-_\.\+]#', $string );
+		$hasEscapedChars = preg_match( '#%[a-zA-Z0-9]{2}#', $string );
+		return !$hasInvalidChars && $hasEscapedChars;
 	}
 
 	protected function decodeRFC2231($string, $charset = 'utf-8') {


### PR DESCRIPTION
Thank you for creating this class. We use it everyday to handle thousands of incoming emails.

Sometimes the filenames of attachments are completely converted, even alnum chars. 

This is a part from an example email, sent from thunderbird. The attachment name is Führerschein (driver's license):
...
Content-Disposition: attachment;
filename_0_=UTF-8''%46%C3%BC%68%72%65%72%73%63%68%65%69%6E;
...

This breaks the detection isUrlEncoded() and the resulting attachment filename is something similar to UTF-8''%46%C3%BC%68%72%65%72%73%63%68%65%69%6E

This commit uses another approach to detect if the filename is url encoded.

I hope this helps a little.
