### PR TITLE
fixed decoding of subject

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -470,7 +470,7 @@ class Mailbox {
 			$data = imap_base64($data);
 		}
 		elseif($partStructure->encoding == 4) {
-			$data = imap_qprint($data);
+			$data = quoted_printable_decode($data);
 		}
 
 		$params = array();


### PR DESCRIPTION
imap_qprint seems to have problems with strings containing the character set (like described here: http://php.net/manual/de/function.imap-qprint.php#4009) - quoted_printable_decode works much better