### PR TITLE
Silence imap_open and imap_get_quotaroot notices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ local.properties
 *.tlb
 *.tli
 *.tlh
-*.tmp
 *.vspscc
 .builds
 *.dotCover
@@ -162,3 +161,5 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+/nbproject/private/
+/nbproject/


### PR DESCRIPTION
imap_* throws notices, if has errors. It's don't silence by `@` sign.

```php
<?php
//...
$mailbox->getImapStream();
```

```
Notice: Unknown: [AUTHENTICATIONFAILED] LOGIN Invalid credentials sc=************ (errflg=1) in Unknown on line 0
```

```php
<?php
//...
@$mailbox->getQuota();
```

```
Notice:  Unknown: Quota not available on this IMAP server (errflg=2) in Unknown on line 0
```

We can disable it and throws Exceptions for correct errors handling.

```php
<?php
//...
try {
    $mailbox->getQuota();
} catch (PhpImap\Exception $exc) {
    // do something good...
}
```