### PR TITLE
Silence imap_open and imap_get_quotaroot notices v.2

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -65,7 +65,9 @@ class Mailbox {
 	protected function initImapStream() {
 		$imapStream = @imap_open($this->imapPath, $this->imapLogin, $this->imapPassword, $this->imapOptions, $this->imapRetriesNum, $this->imapParams);
 		if(!$imapStream) {
-			throw new Exception('Connection error: ' . imap_last_error());
+			$error = imap_last_error();
+			imap_errors();
+			throw new Exception('Connection error: ' . $error);
 		}
 		return $imapStream;
 	}
@@ -377,9 +379,16 @@ class Mailbox {
 	/**
 	 * Retrieve the quota settings per user
 	 * @return array - FALSE in the case of call failure
+	 * @throws Exception
 	 */
 	protected function getQuota() {
-		return imap_get_quotaroot($this->getImapStream(), 'INBOX');
+		$quota = imap_get_quotaroot($this->getImapStream(), 'INBOX');
+		$error = imap_last_error();
+		imap_errors();
+		if ($error) {
+			throw new Exception('Get quota error: ' . $error);
+		}
+		return $quota;
 	}
 
 	/**


### PR DESCRIPTION
imap_* throws notices, if has errors. It's don't silence by `@` sign.

```php
<?php
//...
$mailbox->getImapStream();
```

```
Notice: Unknown: [AUTHENTICATIONFAILED] LOGIN Invalid credentials sc=************ (errflg=1) in Unknown on line 0
```

```php
<?php
//...
@$mailbox->getQuota();
```

```
Notice:  Unknown: Quota not available on this IMAP server (errflg=2) in Unknown on line 0
```

We can disable it and throws Exceptions for correct errors handling.

```php
<?php
//...
try {
    $mailbox->getQuota();
} catch (PhpImap\Exception $exc) {
    // do something good...
}
```