### PR TITLE
Clear Imap Errors

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -73,7 +73,9 @@ class Mailbox {
 	protected function initImapStream() {
 		$imapStream = @imap_open($this->imapPath, $this->imapLogin, $this->imapPassword, $this->imapOptions, $this->imapRetriesNum, $this->imapParams);
 		if(!$imapStream) {
-			throw new Exception('Connection error: ' . imap_last_error());
+			$lastError = imap_last_error();
+			imap_errors();
+			throw new Exception('Connection error: ' . $lastError);
 		}
 		return $imapStream;
 	}


### PR DESCRIPTION
Clear imap errors. If do not clear then imap errors are shown at the end of php script execution even if we tried to catch all exceptions.