### PR TITLE
Add functionality to switch mailbox(es) without opening a new connection

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -70,6 +70,19 @@ class Mailbox {
 		return $this->imapStream;
 	}
 
+	/**
+	 * Switch mailbox without opening a new connection
+	 * 
+	 * @param string $imapPath
+	 */
+	public function switchMailbox($imapPath = '') {
+		$this->imapPath = $imapPath;
+		$imapStream = @imap_reopen($this->getImapStream(), $imapPath);
+		if(!$imapStream) {
+			throw new Exception("Couldn't switch  mailbox: " . imap_last_error());
+		}
+	}
+
 	protected function initImapStream() {
 		$imapStream = @imap_open($this->imapPath, $this->imapLogin, $this->imapPassword, $this->imapOptions, $this->imapRetriesNum, $this->imapParams);
 		if(!$imapStream) {


### PR DESCRIPTION
Currently it's not possible to search multiple folders without re-connecting to the server.
This PR can solve this issue
Just added this simple function to ```Mailbox.php```
```php
	public function switchMailbox($imapPath = '') {
		$this->imapPath = $imapPath;
		$imapStream = @imap_reopen($this->getImapStream(), $imapPath);
		if(!$imapStream) {
			throw new Exception("Couldn't switch  mailbox: " . imap_last_error());
		}
	}
```
Now you can do this:
```php
// Connect to INBOX on server and search for mails
$mailbox = new PhpImap\Mailbox('{imap.example.org.com:993/imap/ssl}INBOX', 'john.doe@example.org', '*********', __DIR__);
$mailIds = $mailbox->searchMailbox('ALL');

// store all mails in $inbox
$inbox = [];
foreach($mailIds as $mailId)
{
	$inbox[] = $mailbox->getMail($mailId, false);
}

// Switch to other folder without opening new connection
$mailbox->switchMailbox('{imap.example.org.com:993/imap/ssl}INBOX.Sent');
$mailIds = $mailbox->searchMailbox('ALL');

// store all mails in $sent
$sent = [];
foreach($mailIds as $mailId)
{
	$sent[] = $mailbox->getMail($mailId, false);
}
```
**HINT**: It's important to fetch the actual mails _BEFORE_ switching to another mailbox.

Hope you'll find this useful.