### PR TITLE
The Content-ID does not indicate that a attach exists

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -523,7 +523,7 @@ class Mailbox {
 			? trim($partStructure->id, " <>")
 			: (isset($params['filename']) || isset($params['name']) ? mt_rand() . mt_rand() : null);
 
-		if($attachmentId) {
+		if($partStructure->ifdisposition) {
 			if(empty($params['filename']) && empty($params['name'])) {
 				$fileName = $attachmentId . '.' . strtolower($partStructure->subtype);
 			}


### PR DESCRIPTION
Some clients send Content-ID header, but Content-Type: text/plain
for example
Content-Type: text/plain; charset="us-ascii"
Content-ID: <151D427DB2A617449D9BC1FF5C13EEF4@test.ru>