### PR TITLE
ignore contentId on body when mail isn't multipart

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -526,6 +526,12 @@ class Mailbox {
 			? trim($partStructure->id, " <>")
 			: (isset($params['filename']) || isset($params['name']) ? mt_rand() . mt_rand() : null);
 
+		// ignore contentId on body when mail isn't multipart (https://github.com/barbushin/php-imap/issues/71)
+		if (!$partNum && TYPETEXT === $partStructure->type)
+		{
+			$attachmentId = null;
+		}
+
 		if($attachmentId) {
 			if(empty($params['filename']) && empty($params['name'])) {
 				$fileName = $attachmentId . '.' . strtolower($partStructure->subtype);


### PR DESCRIPTION
see also https://github.com/barbushin/php-imap/issues/71