### PR TITLE
fix deleteMail function does not work

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -208,7 +208,7 @@ class Mailbox {
 	 * @return bool
 	 */
 	public function deleteMail($mailId) {
-		return imap_delete($this->getImapStream(), $mailId, FT_UID);
+		return imap_delete($this->getImapStream(), $mailId.':'.$mailId, FT_UID);
 	}
 
 	/**


### PR DESCRIPTION
imap_delete() seems to want a range, so to select one, simply range from your id to your id.