### PR TITLE
Prevent Parsing of attachments

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -15,7 +15,7 @@ class Mailbox {
 	protected $imapRetriesNum = 0;
 	protected $imapParams = array();
 	protected $serverEncoding;
-	protected $attachmentsDir = null;
+	protected $sDir = null;
 	protected $expungeOnDisconnect = true;
 	private $imapStream;
 
@@ -614,7 +614,7 @@ class Mailbox {
 		}
 		if(!empty($partStructure->parts)) {
 			foreach($partStructure->parts as $subPartNum => $subPartStructure) {
-				if($partStructure->type == 2 && $partStructure->subtype == 'RFC822' && && $partStructure->disposition !== "attachment") {
+				if($partStructure->type == 2 && $partStructure->subtype == 'RFC822' && $partStructure->disposition !== "attachment") {
 					$this->initMailPart($mail, $subPartStructure, $partNum, $markAsSeen);
 				}
 				else {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -16,7 +16,6 @@ class Mailbox {
 	protected $imapParams = array();
 	protected $serverEncoding;
 	protected $attachmentsDir = null;
-	protected $sDir = null;
 	protected $expungeOnDisconnect = true;
 	private $imapStream;
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -614,7 +614,7 @@ class Mailbox {
 		}
 		if(!empty($partStructure->parts)) {
 			foreach($partStructure->parts as $subPartNum => $subPartStructure) {
-				if($partStructure->type == 2 && $partStructure->subtype == 'RFC822') {
+				if($partStructure->type == 2 && $partStructure->subtype == 'RFC822' && && $partStructure->disposition !== "attachment") {
 					$this->initMailPart($mail, $subPartStructure, $partNum, $markAsSeen);
 				}
 				else {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -15,6 +15,7 @@ class Mailbox {
 	protected $imapRetriesNum = 0;
 	protected $imapParams = array();
 	protected $serverEncoding;
+	protected $attachmentsDir = null;
 	protected $sDir = null;
 	protected $expungeOnDisconnect = true;
 	private $imapStream;


### PR DESCRIPTION
The current version of PHP-Imap does not check if a part is an attachment, and thus will parse an RFC822 compliant file. I don't believe this to be the intended behavior.