### PR TITLE
Fix incorrect shortpath on mailboxes outside INBOX

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -788,7 +788,7 @@ class Mailbox {
 					"fullpath" => $item->name,
 					"attributes" => $item->attributes,
 					"delimiter" => $item->delimiter,
-					"shortpath" => substr($item->name, strlen($this->imapPath) - strlen("INBOX")),
+					"shortpath" => substr($item->name, strpos($item->name, '}') + 1),
 				];
 			}
 		}


### PR DESCRIPTION
Hi,

On mailboxes that are not below `INBOX` the `shortpath` property from `getMailboxes` is incorrect (depending on the lenght of the `fullpath` it will contain parts of `fullpath` or be shorter).

This PR only extracts the part after the `}` of the `fullpath`, thus givin a correct folder name.

Only warning is that this change might break something for users using it and whose IMAP folders are always below `INBOX`