### PR TITLE
Use DateTime for date header and add timezone

### DIFF
--- a/src/PhpImap/IncomingMailHeader.php
+++ b/src/PhpImap/IncomingMailHeader.php
@@ -9,6 +9,7 @@ class IncomingMailHeader {
 	/** @var int|string $id The IMAP message ID - not the "Message-ID:"-header of the email */
 	public $id;
 	public $date;
+	public $dateTime;
 	public $headersRaw;
 	public $headers;
 	public $subject;

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1,5 +1,6 @@
 <?php namespace PhpImap;
 
+use DateTime;
 use stdClass;
 
 /**
@@ -512,8 +513,17 @@ class Mailbox {
 		$header->headersRaw = $headersRaw;
 		$header->headers = $head;
 		$header->id = $mailId;
-		$header->date = date('Y-m-d H:i:s', isset($head->date) ? strtotime(preg_replace('/\(.*?\)/', '', $head->date)) : time());
 		$header->subject = isset($head->subject) ? $this->decodeMimeStr($head->subject, $this->serverEncoding) : null;
+		if(isset($head->date)) {
+			$dateRegex = '/\\s*\\(.*?\\)/';
+			$header->dateTime = DateTime::createFromFormat(DateTime::RFC2822, preg_replace($dateRegex, '', $head->date));
+			$header->date = $header->dateTime->format('Y-m-d H:i:s');
+		}
+		else {
+			$now = new DateTime;
+			$header->date = $now->format('Y-m-d H:i:s');
+		}
+
 		if(isset($head->from)) {
 			$header->fromName = isset($head->from[0]->personal) ? $this->decodeMimeStr($head->from[0]->personal, $this->serverEncoding) : null;
 			$header->fromAddress = strtolower($head->from[0]->mailbox . '@' . $head->from[0]->host);


### PR DESCRIPTION
Fix #209.

I have used my own library for a long time and switched to this one.
However, the invalid date parse is a serious issue.

The code in this PR has been used to process over 10000 mails.

The switch to `DateTime` is not only important to retain timezone information, but also for more reliable parsing.