### PR TITLE
Convert arguments to UTF7 from UTF-8 instead of latin1

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -845,7 +845,7 @@ class Mailbox {
 		}
 		foreach($args as &$arg) {
 			if(is_string($arg)) {
-				$arg = imap_utf7_encode($arg);
+				$arg = mb_convert_encoding($arg, 'UTF7-IMAP', 'UTF-8');
 			}
 		}
 		if($prependConnectionAsFirstArg) {


### PR DESCRIPTION
If my mailbox has Russian name I can't connect to it with `new PhpImap\Mailbox('{imap.yandex.com:993/imap/ssl}' . $folderName , '-@ya.ru', '')`. If I converts `$folderName` before connection with `mb_convert_encoding($folderName, 'UTF7-IMAP', 'UTF-8')` I still have problem because of `imap_utf7_encode()`.