### PR TITLE
SPLIT #239:::Don't convert $args for imap_open

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -843,9 +843,11 @@ class Mailbox {
 		if(!is_array($args)) {
 			$args = [$args];
 		}
-		foreach($args as &$arg) {
-			if(is_string($arg)) {
-				$arg = imap_utf7_encode($arg);
+		if(in_array($methodShortName, ['open', 'reopen', 'search'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
+			foreach($args as &$arg) {
+				if(is_string($arg)) {
+					$arg = imap_utf7_encode($arg);
+				}
 			}
 		}
 		if($prependConnectionAsFirstArg) {


### PR DESCRIPTION
Split PR of #239 all original commits by @commanddotcom only cherry picked, branched, squashed.

This fixes #242 username and password encoding might render the credentials unusable.
