### PR TITLE
SPLIT #239:::Bad encoding

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -228,7 +228,7 @@ class Mailbox {
 	public function getListingFolders($pattern = '*') {
 		$folders = $this->imap('list', [$this->imapPath, $pattern]) ?: [];
 		foreach($folders as &$folder) {
-			$folder = mb_convert_encoding($folder, "UTF-8", "UTF7-IMAP");
+			$folder = mb_convert_encoding($folder, 'UTF-8', 'UTF7-IMAP');
 		}
 		return $folders;
 	}
@@ -741,7 +741,7 @@ class Mailbox {
 	 * @throws Exception
 	 */
 	protected function convertStringEncoding($string, $fromEncoding, $toEncoding) {
-		if(!$string || $fromEncoding == $toEncoding) {
+		if(!$string || $fromEncoding == $toEncoding || (strtoupper($fromEncoding) == 'UTF-8' && strtoupper($toEncoding) == 'US-ASCII')) {
 			return $string;
 		}
 		$convertedString = function_exists('iconv') ? @iconv($fromEncoding, $toEncoding . '//IGNORE', $string) : null;

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -228,7 +228,7 @@ class Mailbox {
 	public function getListingFolders($pattern = '*') {
 		$folders = $this->imap('list', [$this->imapPath, $pattern]) ?: [];
 		foreach($folders as &$folder) {
-			$folder = imap_utf7_decode($folder);
+			$folder = mb_convert_encoding($folder, "UTF-8", "UTF7-IMAP");
 		}
 		return $folders;
 	}
@@ -845,7 +845,7 @@ class Mailbox {
 		}
 		foreach($args as &$arg) {
 			if(is_string($arg)) {
-				$arg = imap_utf7_encode($arg);
+				$arg = mb_convert_encoding($arg, "UTF7-IMAP", "UTF-8");
 			}
 		}
 		if($prependConnectionAsFirstArg) {


### PR DESCRIPTION
Split PR of #239 all original commits by @commanddotcom only cherry picked, branched, squashed.

This fixes #235 and #101 non generic content type encoding.