### PR TITLE
SPLIT #239:::Content as attachments

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -633,7 +633,7 @@ class Mailbox {
 			}
 		}
 
-		$isAttachment = $partStructure->ifid || isset($params['filename']) || isset($params['name']);
+		$isAttachment = isset($params['filename']) || isset($params['name']);
 
 		// ignore contentId on body when mail isn't multipart (https://github.com/barbushin/php-imap/issues/71)
 		if(!$partNum && TYPETEXT === $partStructure->type) {


### PR DESCRIPTION
Split PR of #239 all original commits by @commanddotcom only cherry picked, branched, squashed.

This PR fixes #39 #71 #229 body content gets incorrectly processed as attachments.

plain text and html can have id as well so email part can't be marked as attachment based on id