### PR TITLE
SPLIT #239:::Skip attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,15 @@
 ### Usage example
 
 ```php
-// 4. argument is the directory into which attachments are to be saved:
-$mailbox = new PhpImap\Mailbox('{imap.gmail.com:993/imap/ssl}INBOX', 'some@gmail.com', '*********', __DIR__);
+$mailbox = new PhpImap\Mailbox(
+	'{imap.gmail.com:993/imap/ssl}INBOX', 
+	'some@gmail.com', 
+	'*********', 
+	__DIR__ // The directory into which attachments are to be saved. Ain't saved if FALSE.
+); 
+```
 
+```php
 // Read all messaged into an array:
 $mailsIds = $mailbox->searchMailbox('ALL');
 if(!$mailsIds) {
@@ -44,6 +50,40 @@ $mail = $mailbox->getMail($mailsIds[0]);
 print_r($mail);
 echo "\n\nAttachments:\n";
 print_r($mail->getAttachments());
+```
+
+Method imap() allows to call any imap function in a context of the the instance
+
+```php
+// Call imap_check(); 	
+// http://php.net/manual/en/function.imap-check.php	
+$info = $mailbox->imap('check'); // 
+	
+// Show current time for the mailbox
+$currentServerTime = isset($info->Date) && $info->Date ? date('Y-m-d H:i:s', strtotime($info->Date)) : 'Unknown';	
+	
+echo $currentServerTime;
+```
+
+Some request require much time and resources:
+
+```php
+$mailbox->setAttachmentsIgnore(true); // If you don't need to grab attachments you can significantly increase performance of your application
+
+// get the list of folders/mailboxes	
+$folders = $mailbox->getMailboxes('*'); 	
+	
+// loop through mailboxs	
+foreach($folders as $folder) {	
+	
+	// switch to particular mailbox	
+	$mailbox->switchMailbox($folder['fullpath']); 	
+		
+	// search in particular mailbox	
+	$mails_ids[$folder['fullpath']] = $mailbox->searchMailbox('SINCE "1 Jan 2018" BEFORE "28 Jan 2018"');	
+}	
+	
+print_r($mails_ids);
 ```
 
 ### Recommended

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -20,6 +20,7 @@ class Mailbox {
 	protected $attachmentsDir = null;
 	protected $expungeOnDisconnect = true;
 	protected $timeouts = [];
+	protected $attachmentsIgnore = false;
 	private $imapStream;
 
 	/**
@@ -51,6 +52,13 @@ class Mailbox {
 		$this->serverEncoding = $serverEncoding;
 	}
 
+	/**
+	 * Set $this->attachmentsIgnore param. Allow to ignore attachments when they are not required and boost performance
+	 * @param bool $attachmentsIgnore
+	 */
+	public function setAttachmentsIgnore($attachmentsIgnore) {
+		$this->attachmentsIgnore = $attachmentsIgnore;
+	}
 	/**
 	 * @param int $timeout Timeout in seconds
 	 * @param array $types One of the following: IMAP_OPENTIMEOUT, IMAP_READTIMEOUT, IMAP_WRITETIMEOUT, IMAP_CLOSETIMEOUT
@@ -589,6 +597,14 @@ class Mailbox {
 	}
 
 	protected function initMailPart(IncomingMail $mail, $partStructure, $partNum, $markAsSeen = true) {
+		
+		if ($this->attachmentsIgnore && 
+		($partStructure->type !== TYPEMULTIPART && 
+		($partStructure->type !== TYPETEXT || !in_array(strtolower($partStructure->subtype), ['plain','html']))))
+		{ // skip all but plain and html when attachments are not required
+			return false;
+		}
+		
 		$options = FT_UID;
 		if(!$markAsSeen) {
 			$options |= FT_PEEK;


### PR DESCRIPTION
Split PR of #239 all original commits by @commanddotcom only cherry picked, branched, squashed.

This fixes #150 #167 #122 provides a way to skip processing of attachments when it is not required.