### PR TITLE
Lazy load message text and attachments data

### DIFF
--- a/src/PhpImap/DataPartInfo.php
+++ b/src/PhpImap/DataPartInfo.php
@@ -1,0 +1,58 @@
+<?php namespace PhpImap;
+
+/**
+ * @see https://github.com/barbushin/php-imap
+ * @author nickl- http://github.com/nickl-
+ */
+class DataPartInfo {
+
+    const TEXT_PLAIN = 0;
+    const TEXT_HTML = 1;
+    
+    public $id;
+    public $encoding;
+    public $charset;
+	public $part;
+	public $mail;
+	public $options;
+	private $data;
+	
+	public function __construct($mail, $id, $part, $encoding, $options) {
+	    $this->mail = $mail;
+	    $this->id = $id; 
+	    $this->part = $part;
+	    $this->encoding = $encoding;
+	    $this->options = $options;
+	}
+
+	function fetch() {
+	    if(isset($this->data)) {
+	        return $this->data;
+	    }
+        if($this->part == 0) {
+	        $this->data = $this->mail->imap('body', [$this->id, $this->options]);
+	    }
+	    else {
+	        $this->data = $this->mail->imap('fetchbody', [$this->id, $this->part, $this->options]);
+	    }
+	    switch($this->encoding) {
+	        case ENC8BIT:
+	            $this->data = imap_utf8($this->data);
+                break;
+	        case ENCBINARY:
+	            $this->data = imap_binary($this->data);
+	            break;
+	        case ENCBASE64:
+	            $this->data = preg_replace('~[^a-zA-Z0-9+=/]+~s', '', $this->data); // https://github.com/barbushin/php-imap/issues/88
+	            $this->data = imap_base64($this->data);
+	            break;
+	        case ENCQUOTEDPRINTABLE:
+	            $this->data = quoted_printable_decode($this->data);
+	            break;
+	    }
+	    if(isset($this->charset)) {
+	        $this->data = $this->mail->convertStringEncoding($this->data, $this->charset, $this->mail->getServerEncoding());
+	    }
+	    return $this->data;
+	}
+}

--- a/src/PhpImap/IncomingMail.php
+++ b/src/PhpImap/IncomingMail.php
@@ -3,13 +3,15 @@
 /**
  * @see https://github.com/barbushin/php-imap
  * @author Barbushin Sergey http://linkedin.com/in/barbushin
+ * 
+ * @property-read string $textPlain lazy plain message body
+ * @property-read string $textHtml lazy html message body
  */
 class IncomingMail extends IncomingMailHeader {
 
-	public $textPlain;
-	public $textHtml;
 	/** @var IncomingMailAttachment[] */
 	protected $attachments = array();
+	protected $dataInfo = array([],[]);
 
 	public function setHeader(IncomingMailHeader $header) {
 		foreach(get_object_vars($header) as $property => $value) {
@@ -17,7 +19,29 @@ class IncomingMail extends IncomingMailHeader {
 		}
 	}
 
-	public function addAttachment(IncomingMailAttachment $attachment) {
+	public function addDataPartInfo(DataPartInfo $dataInfo, $type) {
+	    $this->dataInfo[$type][] = $dataInfo;
+	}
+
+	public function __get ($name) {
+	    $type = false;
+	    if($name == 'textPlain') {
+	        $type = DataPartInfo::TEXT_PLAIN;
+	    }
+	    if($name == 'textHtml') {
+	        $type = DataPartInfo::TEXT_HTML;
+	    }
+	    if(false === $type) {
+	        trigger_error("Undefined property: IncomingMail::$name");
+	    }
+	    $this->$name = '';
+	    foreach($this->dataInfo[$type] as $data) {
+	        $this->$name .= trim($data->fetch());
+	    }
+	    return $this->$name;
+	}
+
+    public function addAttachment(IncomingMailAttachment $attachment) {
 		$this->attachments[$attachment->id] = $attachment;
 	}
 

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -3,12 +3,42 @@
 /**
  * @see https://github.com/barbushin/php-imap
  * @author Barbushin Sergey http://linkedin.com/in/barbushin
+ * 
+ * @property-read string $filePath lazy attachment data file
  */
 class IncomingMailAttachment {
 
 	public $id;
 	public $contentId;
 	public $name;
-	public $filePath;
 	public $disposition;
+	private $file_path;
+	private $dataInfo;
+
+	public function __get ($name) {
+	    if($name !== 'filePath') {
+	        trigger_error("Undefined property: IncomingMailAttachment::$name");
+	    }
+        if(!isset($this->file_path)) {
+            return false;
+        }
+        $this->filePath = $this->file_path;
+        if(@file_exists($this->file_path)) {
+            return $this->filePath;
+        }
+        if(false === file_put_contents($this->filePath, $this->dataInfo->fetch())) {
+            unset($this->filePath);
+            unset($this->file_path);
+            return false;
+        }
+        return $this->filePath;
+    }
+
+    public function setFilePath($filePath) {
+        $this->file_path = $filePath;
+    }
+
+    public function addDataPartInfo(DataPartInfo $dataInfo) {
+	    $this->dataInfo = $dataInfo;
+	}
 }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -593,28 +593,8 @@ class Mailbox {
 		if(!$markAsSeen) {
 			$options |= FT_PEEK;
 		}
-
-		if($partNum) { // don't use ternary operator to optimize memory usage / parsing speed (see http://fabien.potencier.org/the-php-ternary-operator-fast-or-not.html)
-			$data = $this->imap('fetchbody', [$mail->id, $partNum, $options]);
-		}
-		else {
-			$data = $this->imap('body', [$mail->id, $options]);
-		}
-
-		if($partStructure->encoding == 1) {
-			$data = imap_utf8($data);
-		}
-		elseif($partStructure->encoding == 2) {
-			$data = imap_binary($data);
-		}
-		elseif($partStructure->encoding == 3) {
-			$data = preg_replace('~[^a-zA-Z0-9+=/]+~s', '', $data); // https://github.com/barbushin/php-imap/issues/88
-			$data = imap_base64($data);
-		}
-		elseif($partStructure->encoding == 4) {
-			$data = quoted_printable_decode($data);
-		}
-
+		$dataInfo = new DataPartInfo($this, $mail->id, $partNum, $partStructure->encoding, $options);
+		
 		$params = [];
 		if(!empty($partStructure->parameters)) {
 			foreach($partStructure->parameters as $param) {
@@ -665,31 +645,31 @@ class Mailbox {
 					'/(^_)|(_$)/' => '',
 				];
 				$fileSysName = preg_replace('~[\\\\/]~', '', $mail->id . '_' . $attachmentId . '_' . preg_replace(array_keys($replace), $replace, $fileName));
-				$attachment->filePath = $this->attachmentsDir . DIRECTORY_SEPARATOR . $fileSysName;
+				$filePath = $this->attachmentsDir . DIRECTORY_SEPARATOR . $fileSysName;
 
-				if(strlen($attachment->filePath) > 255) {
-					$ext = pathinfo($attachment->filePath, PATHINFO_EXTENSION);
-					$attachment->filePath = substr($attachment->filePath, 0, 255 - 1 - strlen($ext)) . "." . $ext;
+				if(strlen($filePath) > 255) {
+					$ext = pathinfo($filePath, PATHINFO_EXTENSION);
+					$filePath = substr($filePath, 0, 255 - 1 - strlen($ext)) . "." . $ext;
 				}
-
-				file_put_contents($attachment->filePath, $data);
+                $attachment->setFilePath($filePath);
 			}
+			$attachment->addDataPartInfo($dataInfo);
 			$mail->addAttachment($attachment);
 		}
 		else {
 			if(!empty($params['charset'])) {
-				$data = $this->convertStringEncoding($data, $params['charset'], $this->serverEncoding);
+			    $dataInfo->charset = $params['charset'];
 			}
-			if($partStructure->type == 0 && $data) {
+			if($partStructure->type === TYPETEXT) {
 				if(strtolower($partStructure->subtype) == 'plain') {
-					$mail->textPlain .= $data;
+					$mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_PLAIN);
 				}
 				else {
-					$mail->textHtml .= $data;
+				    $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_HTML);
 				}
 			}
-			elseif($partStructure->type == 2 && $data) {
-				$mail->textPlain .= trim($data);
+			elseif($partStructure->type === TYPEMESSAGE) {
+			    $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_PLAIN);
 			}
 		}
 		if(!empty($partStructure->parts)) {
@@ -740,7 +720,7 @@ class Mailbox {
 	 * @return string Converted string if conversion was successful, or the original string if not
 	 * @throws Exception
 	 */
-	protected function convertStringEncoding($string, $fromEncoding, $toEncoding) {
+	public function convertStringEncoding($string, $fromEncoding, $toEncoding) {
 		if(!$string || $fromEncoding == $toEncoding) {
 			return $string;
 		}


### PR DESCRIPTION
Something along these lines...

fixes #150 #167 #122  as discussed at #284 

instead of trying to avoid loading attachments rather put it off until it is needed.

we can do the same for text plain and text html as well, what you don't need won't be retrieved.

solution remains non breaking, public lazy load properties are implemented as property magic getter

nJoy!