### PR TITLE
Extended getMailHeader()

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -511,6 +511,8 @@ class Mailbox {
 		$header = new IncomingMailHeader();
 		$header->headersRaw = $headersRaw;
 		$header->headers = $head;
+		$header->autoSubmitted = (preg_match("/Auto-Submitted\:(.*)/i", $headersRaw, $matches)) ? trim($matches[1]) : "";
+		$header->precedence = (preg_match("/Precedence\:(.*)/i", $headersRaw, $matches)) ? trim($matches[1]) : "";
 		$header->id = $mailId;
 		$header->date = date('Y-m-d H:i:s', isset($head->date) ? strtotime(preg_replace('/\(.*?\)/', '', $head->date)) : time());
 		$header->subject = isset($head->subject) ? $this->decodeMimeStr($head->subject, $this->serverEncoding) : null;


### PR DESCRIPTION
Added support for getting the headers "Precedence" and "Auto-Submitted".

Excerpt from the [RFC2076](http://www.faqs.org/rfcs/rfc2076.html):
> *Precedence: Non-standard, controversial, discouraged.*
> Sometimes used as a priority value which can influence transmission speed and delivery. Common values are "bulk" and "first-class". Other uses is to control automatic replies and to control return-of-content facilities, and to stop mailing list loops.

Excerpt from the [RFC3834](https://tools.ietf.org/html/rfc3834):
> *Auto-Submitted field*
> The Auto-Submitted field, with a value of "auto-replied", SHOULD be included in the message header of any automatic response.

I've added this support to be able to parse emails better. Depending on these headers, you can decide, if you send an automatic reply back or not or if you even do anything with this email or not.