### PR TITLE
Extended getMailHeader()

### DIFF
--- a/src/PhpImap/IncomingMailHeader.php
+++ b/src/PhpImap/IncomingMailHeader.php
@@ -11,6 +11,8 @@ class IncomingMailHeader {
 	public $date;
 	public $headersRaw;
 	public $headers;
+	public $autoSubmitted;
+	public $precedence;
 	public $subject;
 
 	public $fromName;


### PR DESCRIPTION
Added support for getting the headers "Precedence" and "Auto-Submitted".

Excerpt from the [RFC2076](http://www.faqs.org/rfcs/rfc2076.html):
> *Precedence: Non-standard, controversial, discouraged.*
> Sometimes used as a priority value which can influence transmission speed and delivery. Common values are "bulk" and "first-class". Other uses is to control automatic replies and to control return-of-content facilities, and to stop mailing list loops.

Excerpt from the [RFC3834](https://tools.ietf.org/html/rfc3834):
> *Auto-Submitted field*
> The Auto-Submitted field, with a value of "auto-replied", SHOULD be included in the message header of any automatic response.

I've added this support to be able to parse emails better. Depending on these headers, you can decide, if you send an automatic reply back or not or if you even do anything with this email or not.