### PR TITLE
Extended getMailHeader()

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -511,6 +511,9 @@ class Mailbox {
 		$header = new IncomingMailHeader();
 		$header->headersRaw = $headersRaw;
 		$header->headers = $head;
+		$header->priority = (preg_match("/Priority\:(.*)/i", $headersRaw, $matches)) ? trim($matches[1]) : "";
+		$header->importance = (preg_match("/Importance\:(.*)/i", $headersRaw, $matches)) ? trim($matches[1]) : "";
+		$header->sensitivity = (preg_match("/Sensitivity\:(.*)/i", $headersRaw, $matches)) ? trim($matches[1]) : "";
 		$header->id = $mailId;
 		$header->date = date('Y-m-d H:i:s', isset($head->date) ? strtotime(preg_replace('/\(.*?\)/', '', $head->date)) : time());
 		$header->subject = isset($head->subject) ? $this->decodeMimeStr($head->subject, $this->serverEncoding) : null;


### PR DESCRIPTION
Added support for getting the following headers:
- **Priority**: Can be "normal", "urgent" or "non-urgent" and can influence transmission speed and delivery. (RFC 1327, not for general usage)
- **Importance**: A hint from the originator to the recipients about how important a message is. Values: High, normal or low. Not used to control transmission speed. (RFC 1327 and RFC 1911, experimental)
- **Sensitivity**: How sensitive it is to disclose this message to other people than the specified recipients. Values: Personal, private, company confidential. The absence of this header in messages gatewayed from X.400 indicates that the message is not sensitive. (RFC 1327 and RFC 1911, experimental)