### PR TITLE
Extended getMailHeader()

### DIFF
--- a/src/PhpImap/IncomingMailHeader.php
+++ b/src/PhpImap/IncomingMailHeader.php
@@ -11,6 +11,9 @@ class IncomingMailHeader {
 	public $date;
 	public $headersRaw;
 	public $headers;
+	public $priority;
+	public $importance;
+	public $sensitivity;
 	public $subject;
 
 	public $fromName;


### PR DESCRIPTION
Added support for getting the following headers:
- **Priority**: Can be "normal", "urgent" or "non-urgent" and can influence transmission speed and delivery. (RFC 1327, not for general usage)
- **Importance**: A hint from the originator to the recipients about how important a message is. Values: High, normal or low. Not used to control transmission speed. (RFC 1327 and RFC 1911, experimental)
- **Sensitivity**: How sensitive it is to disclose this message to other people than the specified recipients. Values: Personal, private, company confidential. The absence of this header in messages gatewayed from X.400 indicates that the message is not sensitive. (RFC 1327 and RFC 1911, experimental)