### PR TITLE
Don't convert $args for imap_open

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -843,7 +843,20 @@ class Mailbox {
 		if(!is_array($args)) {
 			$args = [$args];
 		}
-		if(!in_array($methodShortName, ['open'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
+		 // https://github.com/barbushin/php-imap/issues/242
+		if(in_array($methodShortName, ['open'])) {
+			// Mailbox names that contain international characters besides those in the printable ASCII space have to be encoded with imap_utf7_encode().
+			// https://www.php.net/manual/en/function.imap-open.php
+			if(is_string($args[0])) {
+				if(preg_match("/^\{.*\}(.*)$/", $args[0], $matches)) {
+					$mailbox_name = $matches[1];
+
+					if(!mb_detect_encoding($mailbox_name, 'ASCII', true)) {
+						$args[0] = imap_utf7_encode($mailbox_name);
+					}
+				}
+			}
+		} else {
 			foreach($args as &$arg) {
 				if(is_string($arg)) {
 					$arg = imap_utf7_encode($arg);

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -843,9 +843,11 @@ class Mailbox {
 		if(!is_array($args)) {
 			$args = [$args];
 		}
-		foreach($args as &$arg) {
-			if(is_string($arg)) {
-				$arg = imap_utf7_encode($arg);
+		if(in_array($methodShortName, ['open', 'reopen', 'search'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
+			foreach($args as &$arg) {
+				if(is_string($arg)) {
+					$arg = imap_utf7_encode($arg);
+				}
 			}
 		}
 		if($prependConnectionAsFirstArg) {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -843,7 +843,7 @@ class Mailbox {
 		if(!is_array($args)) {
 			$args = [$args];
 		}
-		if(in_array($methodShortName, ['open', 'reopen', 'search'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
+		if(!in_array($methodShortName, ['open'])) { // duct tape https://github.com/barbushin/php-imap/issues/242
 			foreach($args as &$arg) {
 				if(is_string($arg)) {
 					$arg = imap_utf7_encode($arg);


### PR DESCRIPTION
PR #281 is currently only converting the `$args`, when one of these methods is called:
- open
- reopen
- search

Expected behaviour:
The `$args` should be converted always, except when the method `open` is called. The `open` method is the only imap function, which uses credentials (username + password). The encoding might change these values that they become different to the original provided values.

I've already created a PR in @nickl- repository for this change, but he needs to merge this and update his PR here.

Feel free to close and merge whichever PR you want to. :)