### PR TITLE
Made path delimiter configurable / dynamic and improved de-/encoding of strings

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -140,6 +140,36 @@ class Mailbox {
 	}
 
 	/**
+	 * Returns the provided string in UTF7-IMAP encoded format
+	 *
+	 * @param string $any_encoded_string
+	 * @return string $utf7_encoded_string
+	 */
+	public function encodeStringToUtf7Imap(string $str) {
+		if(is_string($str)) {
+			return mb_convert_encoding($str, 'UTF7-IMAP', mb_detect_encoding($str, 'UTF-8, ISO-8859-1, ISO-8859-15', true));
+		}
+
+		// Return $str as it is, when it is no string
+		return $str;
+	}
+
+	/**
+	 * Returns the provided string in UTF-8 encoded format
+	 *
+	 * @param string $any_encoded_string
+	 * @return string $utf7_encoded_string
+	 */
+	public function decodeStringFromUtf7ImapToUtf8(string $str) {
+		if(is_string($str)) {
+			return mb_convert_encoding($str, 'UTF-8', 'UTF7-IMAP');
+		}
+
+		// Return $str as it is, when it is no string
+		return $str;
+	}
+
+	/**
 	 * Switch mailbox without opening a new connection
 	 *
 	 * @param string $imapPath
@@ -252,7 +282,7 @@ class Mailbox {
 	public function getListingFolders($pattern = '*') {
 		$folders = $this->imap('list', [$this->imapPath, $pattern]) ?: [];
 		foreach($folders as &$folder) {
-			$folder = imap_utf7_decode($folder);
+			$folder = $this->decodeStringFromUtf7ImapToUtf8($folder);
 		}
 		return $folders;
 	}
@@ -858,6 +888,7 @@ class Mailbox {
 	public function unsubscribeMailbox($mailbox) {
 		$this->imap('unsubscribe', $this->imapPath . $this->getPathDelimiter() . $mailbox);
 	}
+
 	/**
 	 * Call IMAP extension function call wrapped with utf7 args conversion & errors handling
 	 *
@@ -881,14 +912,14 @@ class Mailbox {
 					$mailbox_name = $matches[1];
 
 					if(!mb_detect_encoding($mailbox_name, 'ASCII', true)) {
-						$args[0] = imap_utf7_encode($mailbox_name);
+						$args[0] = $this->encodeStringToUtf7Imap($mailbox_name);
 					}
 				}
 			}
 		} else {
 			foreach($args as &$arg) {
 				if(is_string($arg)) {
-					$arg = imap_utf7_encode($arg);
+					$arg = $this->encodeStringToUtf7Imap($arg);
 				}
 			}
 		}

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -20,6 +20,7 @@ class Mailbox {
 	protected $attachmentsDir = null;
 	protected $expungeOnDisconnect = true;
 	protected $timeouts = [];
+	protected $pathDelimiter = '.';
 	private $imapStream;
 
 	/**
@@ -42,6 +43,29 @@ class Mailbox {
 			$this->attachmentsDir = rtrim(realpath($attachmentsDir), '\\/');
 		}
 	}
+
+	/**
+	 * @param string $delimiter Path delimiter
+	 * Supported values are: '.', '/'
+	 */
+	public function setPathDelimiter($delimiter) {
+		$this->pathDelimiter = $delimiter;
+	}
+
+	public function getPathDelimiter() {
+		return $this->pathDelimiter;
+	}
+
+	public function validatePathDelimiter() {
+		$supported_delimiters = array('.', '/');
+
+		if(in_array($this->getPathDelimiter(), $supported_delimiters)) {
+			return true;
+		}
+
+		return false;
+	}
+
 
 	public function getServerEncoding() {
 		return $this->serverEncoding;
@@ -184,7 +208,7 @@ class Mailbox {
 	 * @param $name
 	 */
 	public function createMailbox($name) {
-		$this->imap('createmailbox', $this->imapPath . '.' . $name);
+		$this->imap('createmailbox', $this->imapPath . $this->getPathDelimiter() . $name);
 	}
 
 	/**
@@ -192,7 +216,7 @@ class Mailbox {
 	 * @param $name
 	 */
 	public function deleteMailbox($name) {
-		$this->imap('deletemailbox', $this->imapPath . '.' . $name);
+		$this->imap('deletemailbox', $this->imapPath . $this->getPathDelimiter() . $name);
 	}
 
 	/**
@@ -201,7 +225,7 @@ class Mailbox {
 	 * @param $newName
 	 */
 	public function renameMailbox($oldName, $newName) {
-		$this->imap('renamemailbox', [$this->imapPath . '.' . $oldName, $this->imapPath . '.' . $newName]);
+		$this->imap('renamemailbox', [$this->imapPath . $this->getPathDelimiter() . $oldName, $this->imapPath . $this->getPathDelimiter() . $newName]);
 	}
 
 	/**
@@ -824,7 +848,7 @@ class Mailbox {
 	 * @throws Exception
 	 */
 	public function subscribeMailbox($mailbox) {
-		$this->imap('subscribe', $this->imapPath . '.' . $mailbox);
+		$this->imap('subscribe', $this->imapPath . $this->getPathDelimiter() . $mailbox);
 	}
 
 	/**
@@ -832,7 +856,7 @@ class Mailbox {
 	 * @throws Exception
 	 */
 	public function unsubscribeMailbox($mailbox) {
-		$this->imap('unsubscribe', $this->imapPath . '.' . $mailbox);
+		$this->imap('unsubscribe', $this->imapPath . $this->getPathDelimiter() . $mailbox);
 	}
 	/**
 	 * Call IMAP extension function call wrapped with utf7 args conversion & errors handling

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -116,4 +116,43 @@ final class MailboxTest extends TestCase
 	{
 		$this->assertEquals($this->mailbox->getLogin(), 'php-imap@example.com');
 	}
+
+	/*
+	 * Test, that the path delimiter has a default value
+	*/
+	public function testPathDelimiterHasADefault()
+	{
+		$this->assertNotEmpty($this->mailbox->getPathDelimiter());
+	}
+
+	/*
+	 * Test, that the path delimiter is checked for supported chars
+	*/
+	public function testPathDelimiterIsBeingChecked()
+	{
+		$supported_delimiters = array('.', '/');
+		$random_strings = str_split(substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyz!'§$%&/()=#~*+,;.:<>|"), 0));
+
+		foreach($random_strings as $str) {
+			$this->mailbox->setPathDelimiter($str);
+
+			if(in_array($str, $supported_delimiters)) {
+				$this->assertTrue($this->mailbox->validatePathDelimiter());
+			} else {
+				$this->assertFalse($this->mailbox->validatePathDelimiter());
+			}
+		}
+	}
+
+	/*
+	 * Test, that the path delimiter can be set
+	*/
+	public function testSetAndGetPathDelimiter()
+	{
+		$this->mailbox->setPathDelimiter('.');
+		$this->assertEquals($this->mailbox->getPathDelimiter(), '.');
+
+		$this->mailbox->setPathDelimiter('/');
+		$this->assertEquals($this->mailbox->getPathDelimiter(), '/');
+	}
 }

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -155,4 +155,48 @@ final class MailboxTest extends TestCase
 		$this->mailbox->setPathDelimiter('/');
 		$this->assertEquals($this->mailbox->getPathDelimiter(), '/');
 	}
+
+	/*
+	 * Test, that values are identical before and after encoding
+	*/
+	public function testEncodingReturnsCorrectValues()
+	{
+		$test_strings = array(
+			'Avañe’ẽ', // Guaraní
+			'azərbaycanca', // Azerbaijani (Latin)
+			'Bokmål', // Norwegian Bokmål
+			'chiCheŵa', // Chewa
+			'Deutsch', // German
+			'U.S. English', // U.S. English
+			'français', // French
+			'føroyskt', // Faroese
+			'Kĩmĩrũ', // Kimîîru
+			'Kɨlaangi', // Langi
+			'oʼzbekcha', // Uzbek (Latin)
+			'Plattdüütsch', // Low German
+			'română', // Romanian
+			'Sängö', // Sango
+			'Tiếng Việt', // Vietnamese
+			'ɔl-Maa', // Masai
+			'Ελληνικά', // Greek
+			'Ўзбек', // Uzbek (Cyrillic)
+			'Азәрбајҹан', // Azerbaijani (Cyrillic)
+			'Српски', // Serbian (Cyrillic)
+			'русский', // Russian
+			'ѩзыкъ словѣньскъ', // Church Slavic
+			'العربية', // Arabic
+			'नेपाली', // / Nepali
+			'日本語', // Japanese
+			'简体中文', // Chinese (Simplified)
+			'繁體中文', // Chinese (Traditional)
+			'한국어', // Korean
+		);
+
+		foreach($test_strings as $str) {
+			$utf7_encoded_str = $this->mailbox->encodeStringToUtf7Imap($str);
+			$utf8_decoded_str = $this->mailbox->decodeStringFromUtf7ImapToUtf8($utf7_encoded_str);
+
+			$this->assertEquals($utf8_decoded_str, $str);
+		}
+	}
 }


### PR DESCRIPTION
- Added functions to set/get path delimiter
- Added default value `.` for property `path delimiter` as this was used before in the code
- Added PHPUnit tests for path delimiter

This solves #213.

```
$ phpunit --testdox
PHPUnit 7.5.9 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.26-2+0~20190216175340.13+stretch~1.gbpc20626
Configuration: /home/sebastian/git/php-imap/phpunit.xml

Mailbox
 ✔ Constructor [3.78 ms]
 ✔ Constructor trims possible variables [0.33 ms]
 ✔ Constructor uppers server encoding [0.06 ms]
 ✔ Set and get server encoding [0.05 ms]
 ✔ Get login [0.04 ms]
 ✔ Path delimiter has a default [0.34 ms]
 ✔ Path delimiter is being checked [0.31 ms]
 ✔ Set and get path delimiter [0.05 ms]

Requirements
 ✔ Php imap extension is enabled [0.05 ms]

Time: 44 ms, Memory: 4.00 MB

OK (9 tests, 71 assertions)
```