### PR TITLE
Move phpunit to require-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Install the latest available and may unstable source code from `develop`, which 
 
 You can run all PHPUnit tests by running the following command (inside of the installed `php-imap` directory): `php vendor/bin/phpunit --testdox`
 
+Before you can run the PHPUnit tests you may need to run `composer install` to install all (development) dependencies. 
+
 ### Integration with frameworks
 
 * Symfony - https://github.com/secit-pl/imap-bundle

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,10 @@
     ],
     "require": {
         "php": ">=5.6",
-        "ext-imap": "*",
-        "phpunit/phpunit": "^5.7"
+        "ext-imap": "*"
+    },
+    "require-dev": {
+      "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
phpunit is not required in production, only for development.

Fixes #302 