### PR TITLE
move phpunit to require dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     ],
     "require": {
         "php": ">=5.6",
-        "ext-imap": "*",
+        "ext-imap": "*"
+    },
+    "require-dev": {
         "phpunit/phpunit": "^5.7"
     },
     "autoload": {


### PR DESCRIPTION
PHPUnit should be in the require dev, not require.

This change broke my project, which requires phpunit 6+.