### PR TITLE
Saving an email should not change the unread state

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "php-imap/php-imap",
+    "name": "yachtfocus/php-imap",
     "description": "Manage mailboxes, filter/get/delete emails in PHP (supports IMAP/POP3/NNTP)",
     "keywords": [
         "PHP",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "yachtfocus/php-imap",
+    "name": "php-imap/php-imap",
     "description": "Manage mailboxes, filter/get/delete emails in PHP (supports IMAP/POP3/NNTP)",
     "keywords": [
         "PHP",

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -250,7 +250,7 @@ class Mailbox {
 	 * @param string $filename
 	 */
 	public function saveMail($mailId, $filename = 'email.eml') {
-		$this->imap('savebody', [$filename, $mailId, "", FT_UID]);
+		$this->imap('savebody', [$filename, $mailId, "", FT_UID | FT_PEEK]);
 	}
 
 	/**


### PR DESCRIPTION
We scan people's mailboxes and download their messages into our system. But we don't want every email to be marked as 'read', as they manage their mailbox themselves otherwise.