### PR TITLE
 Fix an issue that checking valid params in the setConnectionArgs function.

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -217,7 +217,7 @@ class Mailbox {
 			}
 
 			foreach($params as $key => $value) {
-				if(!array_key_exists($key, $supported_params)) {
+				if(!in_array($key, $supported_params)) {
 					throw new InvalidParameterException('Invalid array key of params provided for setConnectionArgs()! Only DISABLE_AUTHENTICATOR is currently valid.');
 				}
 			}


### PR DESCRIPTION
array_key_exists() -> in_array()