### PR TITLE
Fix for parsing parts do not work properly

### DIFF
--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -13,6 +13,7 @@ class IncomingMailAttachment {
 	public $name;
 	public $disposition;
 	public $charset;
+	public $emlOrigin;
 	private $file_path;
 	private $dataInfo;
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -919,7 +919,7 @@ class Mailbox {
 				}else if ($partStructure->subtype == 'RFC822' && $partStructure->disposition == 'attachment') {
 					//If it comes from am EML attachment, download each part separately as a file
 					$this->initMailPart($mail, $subPartStructure, $partNum . '.' . ($subPartNum + 1), $markAsSeen, true);
-				}else {
+				}else{
 					$this->initMailPart($mail, $subPartStructure, $partNum . '.' . ($subPartNum + 1), $markAsSeen);
 				}
 			}


### PR DESCRIPTION
Although, it is not the ideal solution for this problem, but I've been able to make it works with eml files,

Using the actual branch (develop), I've been able to:
- Download de the eml file as ".eml" attached file
- Download each file "inside" fhe eml as a different attachment
- "Mark" (as a parameter called "emlOrigin") if the attachment comes from an eml files

Example, of processed EML "attachment":
- 10431_5845944131528768489_5845944131528768489.rfc822.eml
- 10431_9025868031894177481_9025868031894177481.plain

@Sebi94nbg , what do you think? Any problems than colud arise with this solution?

To do this, the code to download the attchment has been split into another function (downloadAttachment). If it is ok, could someone help me with the comments? English is not my primary language.
