### PR TITLE
Windows charset conversions

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1019,8 +1019,8 @@ class Mailbox {
 		$mbLoaded = extension_loaded('mbstring');
 		$supportedEncodings = [];
 		if($mbLoaded) {
-		    $supportedEncodings = array_map('strtolower', mb_list_encodings());
-        }
+			$supportedEncodings = array_map('strtolower', mb_list_encodings());
+		}
 		if($mbLoaded && in_array(strtolower($fromEncoding), $supportedEncodings) && in_array(strtolower($toEncoding), $supportedEncodings)) {
 			$convertedString = mb_convert_encoding($string, $toEncoding, $fromEncoding);
 		} elseif(function_exists('iconv')) {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1013,10 +1013,15 @@ class Mailbox {
 	 * @throws Exception
 	 */
 	public function convertStringEncoding($string, $fromEncoding, $toEncoding) {
-		if(preg_match("/default|ascii|windows/i", $fromEncoding) || !$string || $fromEncoding == $toEncoding) {
+		if(preg_match("/default|ascii/i", $fromEncoding) || !$string || $fromEncoding == $toEncoding) {
 			return $string;
 		}
-		if(extension_loaded('mbstring')) {
+		$mbLoaded = extension_loaded('mbstring');
+		$supportedEncodings = [];
+		if($mbLoaded) {
+		    $supportedEncodings = array_map('strtolower', mb_list_encodings());
+        }
+		if($mbLoaded && in_array(strtolower($fromEncoding), $supportedEncodings) && in_array(strtolower($toEncoding), $supportedEncodings)) {
 			$convertedString = mb_convert_encoding($string, $toEncoding, $fromEncoding);
 		} elseif(function_exists('iconv')) {
 			$convertedString = iconv($fromEncoding, $toEncoding . '//IGNORE', $string);


### PR DESCRIPTION
Resolve an issue #335 introduced with e4d5130b7d539bc636c397c68f7c94cb62ef8e3b

The mentioned commit caused convertStringEncoding method to skip conversion if the source encoding was one of the windows encodings. This changes make the method fallback to iconv if the source or final encoding are not found in the list of encodings returned by mb_list_encodings().