### PR TITLE
Fixes "decodeMimeStr() Can not decode an empty" error when mail has no subject.

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -668,7 +668,7 @@ class Mailbox
         $mails = $this->imap('fetch_overview', [implode(',', $mailsIds), (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
         if (\is_array($mails) && \count($mails)) {
             foreach ($mails as &$mail) {
-                if (isset($mail->subject)) {
+                if (!empty($mail->subject)) {
                     $mail->subject = $this->decodeMimeStr($mail->subject, $this->getServerEncoding());
                 }
                 if (isset($mail->from) and !empty($mail->from)) {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -668,7 +668,7 @@ class Mailbox
         $mails = $this->imap('fetch_overview', [implode(',', $mailsIds), (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
         if (\is_array($mails) && \count($mails)) {
             foreach ($mails as &$mail) {
-                if (!empty($mail->subject)) {
+                if (isset($mail->subject) and !empty($mail->subject)) {
                     $mail->subject = $this->decodeMimeStr($mail->subject, $this->getServerEncoding());
                 }
                 if (isset($mail->from) and !empty($mail->from)) {


### PR DESCRIPTION
Subject must be checked is not empty.