### PR TITLE
trim $to->personal field before decoding

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -865,7 +865,7 @@ class Mailbox
             foreach ($head->to as $to) {
                 if (!empty($to->mailbox) && !empty($to->host)) {
                     $toEmail = strtolower($to->mailbox.'@'.$to->host);
-                    $toName = (isset($to->personal) and !empty($to->personal)) ? $this->decodeMimeStr($to->personal, $this->getServerEncoding()) : null;
+                    $toName = (isset($to->personal) and !empty(trim($to->personal))) ? $this->decodeMimeStr($to->personal, $this->getServerEncoding()) : null;
                     $toStrings[] = $toName ? "$toName <$toEmail>" : $toEmail;
                     $header->to[$toEmail] = $toName;
                 }


### PR DESCRIPTION
Sometimes I receive emails with the next raw header:
```
........
Date: Wed, 26 Jun 2019 07:49:33 +0100
Subject: 20% OFF GARDEN FURNITURE!!
From: TJ Hughes <no-reply@tjhughes.co.uk>
To: " " <myemail@gmail.com>
Content-Type: multipart/alternative;
.........
```
You can clearly see a space in "To" field. So instead of simply skipping this field I got an Exception and can not fetch email at all. I suggest that trim is using before decoding in this case.