### PR TITLE
ContentId based attachment key calculation

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1093,7 +1093,7 @@ class Mailbox
             $fileName = $fileName;
         }
 
-        $attachmentId = sha1($fileName);
+        $attachmentId = sha1($fileName.$partStructure->id);
 
         $attachment = new IncomingMailAttachment();
         $attachment->id = $attachmentId;


### PR DESCRIPTION
There is an issue with google mail messages composed via web-mail. Message composer supports clipboard image paste direct into the body. When I received the email, I didn't see all the attachments, because google web-mail assigns the same image name for any pasted images.

The issue is solved when we generate attachment.id based on content.id.