### PR TITLE
iconv in convertStringEncoding trieds to TRANSLIT first before ignore illegal encoding characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install the [latest available release](https://github.com/barbushin/php-imap/rel
 
 Install the latest available and stable source code from `master`, which is may not released / tagged yet:
 
-	$ composer require php-imap/php-imap
+	$ composer require php-imap/php-imap:dev-master
 
 Install the latest available and may unstable source code from `develop`, which is may not properly tested yet:
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1222,7 +1222,7 @@ class Mailbox
         if ($mbLoaded && \in_array(strtolower($fromEncoding), $supportedEncodings) && \in_array(strtolower($toEncoding), $supportedEncodings)) {
             $convertedString = mb_convert_encoding($string, $toEncoding, $fromEncoding);
         } elseif (\function_exists('iconv')) {
-            $convertedString = iconv($fromEncoding, $toEncoding.'//IGNORE', $string);
+            $convertedString = iconv($fromEncoding, $toEncoding.'//TRANSLIT//IGNORE', $string);
         }
         if (!isset($convertedString)) {
             throw new Exception('Mime string encoding conversion failed');

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1093,7 +1093,7 @@ class Mailbox
             $fileName = $fileName;
         }
 
-        $attachmentId = sha1($fileName . ($partStructure->ifid ? $partStructure->id : ""));
+        $attachmentId = sha1($fileName.($partStructure->ifid ? $partStructure->id : ''));
 
         $attachment = new IncomingMailAttachment();
         $attachment->id = $attachmentId;

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1093,7 +1093,7 @@ class Mailbox
             $fileName = $fileName;
         }
 
-        $attachmentId = sha1($fileName.$partStructure->id);
+        $attachmentId = sha1($fileName . ($partStructure->ifid ? $partStructure->id : ""));
 
         $attachment = new IncomingMailAttachment();
         $attachment->id = $attachmentId;


### PR DESCRIPTION
For some cases if characters set is not detected correctly iconv will remove characters from content and that makes it hard to read. 

For example if original text is 
> Geri vyrai gerą girą gėrė

It's possible to get the result that looks like this:
> Geri vyrai ger gir gr

With transliteration enabled it's easier to read text when such problem happens. The result would look like this:
> Geri vyrai gera gira gere

This one line change adds such functionality.