### PR TITLE
Bugfix update getCombinedPath and switchMailbox

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1409,22 +1409,17 @@ class Mailbox
      */
     protected function getCombinedPath($folder, $absolute = false)
     {
-        if (!empty($folder)) {
-            if ('}' === substr($this->imapPath, -1)) {
-                return $this->imapPath.$folder;
-            }
-            if (true === $absolute) {
-                if ('/' === $folder) {
-                    $folder = '';
-                }
-                $posConnectionDefinitionEnd = strpos($this->imapPath, '}');
+        if (empty($folder)) {
+            return $this->imapPath;
+        } elseif ('}' === substr($this->imapPath, -1)) {
+            return $this->imapPath.$folder;
+        } elseif (true === $absolute) {
+            $folder = ('/' === $folder) ? '' : $folder;
+            $posConnectionDefinitionEnd = strpos($this->imapPath, '}');
 
-                return substr($this->imapPath, 0, $posConnectionDefinitionEnd + 1).$folder;
-            }
-
-            return $this->imapPath.$this->getPathDelimiter().$folder;
+            return substr($this->imapPath, 0, $posConnectionDefinitionEnd + 1).$folder;
         }
 
-        return $this->imapPath;
+        return $this->imapPath.$this->getPathDelimiter().$folder;
     }
 }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -367,8 +367,13 @@ class Mailbox
      */
     public function switchMailbox($imapPath)
     {
-        $this->imapPath = $imapPath;
-        $this->imap('reopen', $this->getCombinedPath($imapPath, true));
+        if (strpos($imapPath, '}') > 0) {
+            $this->imapPath = $imapPath;
+        } else {
+            $this->imapPath = $this->getCombinedPath($imapPath, true);
+        }
+
+        $this->imap('reopen', $this->imapPath);
     }
 
     protected function initImapStreamWithRetry()
@@ -1405,13 +1410,19 @@ class Mailbox
     protected function getCombinedPath($folder, $absolute = false)
     {
         if (!empty($folder)) {
-            if ('}' === substr($this->imapPath, -1) || true === $absolute) {
+            if ('}' === substr($this->imapPath, -1)) {
+                return $this->imapPath.$folder;
+            }
+            if (true === $absolute) {
+                if ('/' === $folder) {
+                    $folder = '';
+                }
                 $posConnectionDefinitionEnd = strpos($this->imapPath, '}');
 
                 return substr($this->imapPath, 0, $posConnectionDefinitionEnd + 1).$folder;
-            } else {
-                return $this->imapPath.$this->getPathDelimiter().$folder;
             }
+
+            return $this->imapPath.$this->getPathDelimiter().$folder;
         }
 
         return $this->imapPath;


### PR DESCRIPTION
FIX incorrectly implemented #360 (switchMailbox) and result bug in #372 

Works with
```
* {mail.example.com:143/imap/tls/validate-cert}INBOX
* {mail.example.com:143/imap/tls/validate-cert}
````
Tested with short path folder:
````
//{mail.example.com:143/imap/tls/validate-cert}test
$mailbox->switchMailbox("test");
$idss = $mailbox->searchMailbox('ALL',true);
var_dump($idss);
````
new feature to switch back to root folder. It is BC. Also fullpath test
````
$mailbox->switchMailbox("/");
$folders = $mailbox->getMailboxes('*');

foreach($folders as $folder) {
	$mailbox->switchMailbox($folder['fullpath']);
       $ids = $mailbox->searchMailbox('ALL',true);
       var_dump($ids);
}
````