### PR TITLE
Various attachment related imporevements

### DIFF
--- a/src/PhpImap/IncomingMail.php
+++ b/src/PhpImap/IncomingMail.php
@@ -110,6 +110,22 @@ class IncomingMail extends IncomingMailHeader
     }
 
     /**
+     * @param string $id The attachment id
+     *
+     * @return bool
+     */
+    public function removeAttachment( $id )
+    {
+      if( !isset($this->attachments[$id]) ) {
+        return false;
+      }
+
+      unset($this->attachments[$id]);
+
+      return true;
+    }
+
+    /**
      * Get array of internal HTML links placeholders.
      *
      * @return array attachmentId => link placeholder

--- a/src/PhpImap/IncomingMail.php
+++ b/src/PhpImap/IncomingMail.php
@@ -116,13 +116,13 @@ class IncomingMail extends IncomingMailHeader
      */
     public function removeAttachment( $id )
     {
-      if( !isset($this->attachments[$id]) ) {
-        return false;
-      }
+        if( !isset($this->attachments[$id]) ) {
+            return false;
+        }
 
-      unset($this->attachments[$id]);
+        unset($this->attachments[$id]);
 
-      return true;
+        return true;
     }
 
     /**

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -78,7 +78,7 @@ class IncomingMailAttachment
     public function getMimeType()
     {
         if( !$this->mimeType ) {
-            if( !class_exists("finfo") ) {
+            if( class_exists("finfo") ) {
                 $finfo = new finfo(FILEINFO_MIME);
 
                 $this->mimeType = $finfo->buffer($this->getContents());

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -64,4 +64,12 @@ class IncomingMailAttachment
 
         return true;
     }
+
+    /**
+     * @return string
+     */
+    public function getContents()
+    {
+        return $this->dataInfo->fetch();
+    }
 }

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -2,6 +2,8 @@
 
 namespace PhpImap;
 
+use finfo;
+
 /**
  * @see https://github.com/barbushin/php-imap
  *
@@ -19,6 +21,11 @@ class IncomingMailAttachment
     public $emlOrigin;
     private $file_path;
     private $dataInfo;
+
+    /**
+     * @var string
+     */
+    private $mimeType;
 
     public function __get($name)
     {
@@ -63,6 +70,22 @@ class IncomingMailAttachment
         }
 
         return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMimeType()
+    {
+        if( !$this->mimeType ) {
+            if( !class_exists("finfo") ) {
+                $finfo = new finfo(FILEINFO_MIME);
+
+                $this->mimeType = $finfo->buffer($this->getContents());
+            }
+        }
+
+        return $this->mimeType;
     }
 
     /**


### PR DESCRIPTION
This PR:

1) Allows for an attachment to be retrieved as a string without being saved as a file
2) Provides a method to retrieve the mime type of an attachment
3) Allows for IncomingEmail to remove an attachment by id
4) Adds a method to IncomingEmail that can embed inline image attachments as base64 encoded data to the <img> tag