### PR TITLE
Fix switchMailbox

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -286,7 +286,7 @@ class Mailbox
         return $this->attachmentsDir;
     }
 
-    /*
+    /**
      * Sets / Changes the attempts / retries to connect
      * @param int $maxAttempts
      * @return void
@@ -296,7 +296,7 @@ class Mailbox
         $this->connectionRetry = $maxAttempts;
     }
 
-    /*
+    /**
      * Sets / Changes the delay between each attempt / retry to connect
      * @param int $milliseconds
      * @return void
@@ -367,8 +367,8 @@ class Mailbox
      */
     public function switchMailbox($imapPath)
     {
-        $this->imapPath = $imapPath;
-        $this->imap('reopen', $this->getCombinedPath($imapPath, true));
+        $this->imapPath = $this->getCombinedPath($imapPath, true);
+        $this->imap('reopen', $this->imapPath);
     }
 
     protected function initImapStreamWithRetry()
@@ -1402,13 +1402,14 @@ class Mailbox
      *
      * @return string Return the new path
      */
-    protected function getCombinedPath($folder, $absolute = false)
+    public function getCombinedPath($folder, $absolute = false)
     {
         if (!empty($folder)) {
+            if (strpos($folder, '}')) {
+                $folder = substr($folder, strpos($folder, '}')+1);
+            }
             if ('}' === substr($this->imapPath, -1) || true === $absolute) {
-                $posConnectionDefinitionEnd = strpos($this->imapPath, '}');
-
-                return substr($this->imapPath, 0, $posConnectionDefinitionEnd + 1).$folder;
+                return substr($this->imapPath, 0, strpos($this->imapPath, '}')+1).$folder;
             } else {
                 return $this->imapPath.$this->getPathDelimiter().$folder;
             }

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -658,4 +658,26 @@ final class MailboxTest extends TestCase
         $this->mailbox->setServerEncoding($serverEncoding);
         $this->assertEquals($this->mailbox->decodeMimeStr($str, $this->mailbox->getServerEncoding()), $expectedStr);
     }
+
+    /**
+     * Provides test data for testing getCombinedPath.
+     */
+    public function combinedPathProvider()
+    {
+        return [
+            ['SubFolder', '{imap.example.com:993/imap/ssl/novalidate-cert}INBOX.SubFolder', false],
+            ['MYFOLDER', '{imap.example.com:993/imap/ssl/novalidate-cert}MYFOLDER', true],
+            ['{imap.example.com:993/imap/ssl/novalidate-cert}MYFOLDER', '{imap.example.com:993/imap/ssl/novalidate-cert}MYFOLDER', true],
+        ];
+    }
+
+    /**
+     * Tests the returned value of getCombinedPath function
+     *
+     * @dataProvider combinedPathProvider
+     */
+    public function testCombinedPath($folder, $expectedStr, $absolute)
+    {
+        $this->assertEquals($expectedStr, $this->mailbox->getCombinedPath($folder, $absolute));
+    }
 }


### PR DESCRIPTION
As described in the documentation the `switchMailbox `function is expecting an `imapPath `parameter with `'fullpath'`. 

This commit fix the case were `getCombinedPath `method receives a `folder `parameter with 'fullpath'.