### PR TITLE
Bug fixes and improvements

### DIFF
--- a/examples/get_and_parse_unseen_emails_save_attachments_one_by_one.php
+++ b/examples/get_and_parse_unseen_emails_save_attachments_one_by_one.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Example: Get and parse all unseen emails with saving their attachments one by one.
+ * 
+ * @author Sebastian Krätzig <info@ts3-tools.info>
+ */
+
+    require_once __DIR__ . '/../vendor/autoload.php';
+    use PhpImap\Mailbox;
+    use PhpImap\Exceptions\ConnectionException;
+
+    $mailbox = new Mailbox(
+        '{imap.gmail.com:993/imap/ssl}INBOX', // IMAP server and mailbox folder
+        'some@gmail.com', // Username for the before configured mailbox
+        '*********' // Password for the before configured username
+    );
+
+    try {
+        $mail_ids = $mailbox->searchMailbox('UNSEEN');
+    } catch(ConnectionException $ex) {
+        die("IMAP connection failed: " . $ex->getMessage());
+    } catch (Exception $ex) {
+        die("An error occured: " . $ex->getMessage());
+    }
+
+    foreach ($mail_ids as $mail_id) {
+        echo "+------ P A R S I N G ------+\n";
+
+        $email = $mailbox->getMail(
+            $mail_id, // ID of the email, you want to get
+            false // Do NOT mark emails as seen (optional)
+        );
+
+        echo "from-name: " . (isset($email->fromName)) ? $email->fromName : $email->fromAddress . "\n";
+        echo "from-email: " . $email->fromAddress . "\n";
+        echo "to: " . $email->to . "\n";
+        echo "subject: " . $email->subject . "\n";
+        echo "message_id: " . $email->messageId . "\n";
+    
+        echo "mail has attachments? ";
+        if ($email->hasAttachments()) {
+            echo "Yes\n";
+        } else {
+            echo "No\n";
+        }
+    
+        if (! empty($email->getAttachments())) {
+            echo count($email->getAttachments()) . " attachements\n";
+        }
+
+        // Save attachments one by one
+        if (! $mbox_connection->getAttachmentsIgnore()) {
+            $attachments = $email_content->getAttachments();
+
+            foreach ($attachments as $attachment) {
+                echo "--> Saving " . $attachment->name . "...";
+
+                // Set individually filePath for each single attachment
+                // In this case, every file will get the current Unix timestamp
+                $attachment->setFilePath(__DIR__.'/files/'.time());
+
+                if ($attachment->saveToDisk()) {
+                    echo "OK, saved!\n";
+                } else {
+                    echo "ERROR, could not save!\n";
+                }
+            }
+        }
+
+        if ($email->textHtml) {
+            echo "Message HTML:\n" . $email->textHtml;
+        } else {
+            echo "Message Plain:\n" . $email->textPlain;
+        }
+    
+        if (!empty($email->autoSubmitted)) {
+            // Mark email as "read" / "seen"
+            $mailbox->markMailAsRead($mail_id);
+                    echo "+------ IGNORING: Auto-Reply ------+\n";
+        }
+    
+        if (!empty($email_content->precedence)) {
+            // Mark email as "read" / "seen"
+            $mailbox->markMailAsRead($mail_id);
+            echo "+------ IGNORING: Non-Delivery Report/Receipt ------+\n";
+        }    
+    }
+
+    $mailbox->disconnect();

--- a/src/PhpImap/DataPartInfo.php
+++ b/src/PhpImap/DataPartInfo.php
@@ -31,10 +31,6 @@ class DataPartInfo
 
     public function fetch()
     {
-        if (isset($this->data)) {
-            return $this->data;
-        }
-
         if (0 == $this->part) {
             $this->data = $this->mail->imap('body', [$this->id, $this->options]);
         } else {

--- a/src/PhpImap/DataPartInfo.php
+++ b/src/PhpImap/DataPartInfo.php
@@ -66,7 +66,7 @@ class DataPartInfo
                 break;
         }
 
-        if (isset($this->charset) and !empty($this->charset)) {
+        if (isset($this->charset) and !empty(trim($this->charset))) {
             $this->data = $this->mail->convertStringEncoding($this->data, $this->charset, $this->mail->getServerEncoding());
         }
 

--- a/src/PhpImap/DataPartInfo.php
+++ b/src/PhpImap/DataPartInfo.php
@@ -67,7 +67,11 @@ class DataPartInfo
         }
 
         if (isset($this->charset) and !empty(trim($this->charset))) {
-            $this->data = $this->mail->convertStringEncoding($this->data, $this->charset, $this->mail->getServerEncoding());
+            $this->data = $this->mail->convertStringEncoding(
+                $this->data, // Data to convert
+                $this->charset, // FROM-Encoding (Charset)
+                $this->mail->getServerEncoding() // TO-Encoding (Charset)
+            );
         }
 
         return $this->data;

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -63,6 +63,10 @@ class IncomingMailAttachment
      */
     public function saveToDisk()
     {
+        if (is_null($this->dataInfo)) {
+            return false;
+        }
+
         if (false === file_put_contents($this->filePath, $this->dataInfo->fetch())) {
             unset($this->filePath);
             unset($this->file_path);

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -46,35 +46,28 @@ class IncomingMailAttachment
         return $this->filePath;
     }
 
+    /**
+     * Sets the file path.
+     * 
+     * @param string $filePath File path incl. file name and optional extension
+     *
+     * @return void
+     */
     public function setFilePath($filePath)
     {
         $this->file_path = $filePath;
     }
 
+    /**
+     * Sets the data part info.
+     * 
+     * @param DataPartInfo $dataInfo Date info (file content)
+     *
+     * @return void
+     */
     public function addDataPartInfo(DataPartInfo $dataInfo)
     {
         $this->dataInfo = $dataInfo;
-    }
-
-    /**
-     * Saves the attachment object on the disk.
-     *
-     * @return bool True, if it could save the attachment on the disk
-     */
-    public function saveToDisk()
-    {
-        if (is_null($this->dataInfo)) {
-            return false;
-        }
-
-        if (false === file_put_contents($this->filePath, $this->dataInfo->fetch())) {
-            unset($this->filePath);
-            unset($this->file_path);
-
-            return false;
-        }
-
-        return true;
     }
 
     /**
@@ -96,10 +89,33 @@ class IncomingMailAttachment
     }
 
     /**
+     * Gets the file content.
+     * 
      * @return string
      */
     public function getContents()
     {
         return $this->dataInfo->fetch();
+    }
+
+    /**
+     * Saves the attachment object on the disk.
+     *
+     * @return bool True, if it could save the attachment on the disk
+     */
+    public function saveToDisk()
+    {
+        if (is_null($this->dataInfo)) {
+            return false;
+        }
+
+        if (false === file_put_contents($this->filePath, $this->dataInfo->fetch())) {
+            unset($this->filePath);
+            unset($this->file_path);
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1125,7 +1125,7 @@ class Mailbox
      *
      * @return IncomingMailAttachment[] $attachment
      */
-    public function downloadAttachment($dataInfo, $params, $partStructure, $mailId, $emlOrigin = false)
+    public function downloadAttachment(DataPartInfo $dataInfo, $params, $partStructure, $mailId, $emlOrigin = false)
     {
         if ('RFC822' == $partStructure->subtype && isset($partStructure->disposition) && 'attachment' == $partStructure->disposition) {
             $fileExt = strtolower($partStructure->subtype).'.eml';

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1288,6 +1288,9 @@ class Mailbox
         return $convertedString;
     }
 
+    /**
+     * Disconnects from the IMAP server / mailbox.
+     */
     public function __destruct()
     {
         $this->disconnect();

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -267,7 +267,7 @@ class Mailbox
      */
     public function setAttachmentsDir($attachmentsDir)
     {
-        if (empty($attachmentsDir)) {
+        if (empty(trim($attachmentsDir))) {
             throw new InvalidParameterException('setAttachmentsDir() expects a string as first parameter!');
         }
         if (!is_dir($attachmentsDir)) {
@@ -408,7 +408,7 @@ class Mailbox
         if (!$imapStream) {
             $lastError = imap_last_error();
 
-            if (!empty($lastError)) {
+            if (!empty(trim($lastError))) {
                 // imap error = report imap error
                 throw new Exception('IMAP error: '.$lastError);
             } else {
@@ -716,16 +716,16 @@ class Mailbox
         $mails = $this->imap('fetch_overview', [implode(',', $mailsIds), (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
         if (\is_array($mails) && \count($mails)) {
             foreach ($mails as &$mail) {
-                if (isset($mail->subject) and !empty($mail->subject)) {
+                if (isset($mail->subject) and !empty(trim($mail->subject))) {
                     $mail->subject = $this->decodeMimeStr($mail->subject, $this->getServerEncoding());
                 }
-                if (isset($mail->from) and !empty($mail->from)) {
+                if (isset($mail->from) and !empty(trim($mail->from))) {
                     $mail->from = $this->decodeMimeStr($mail->from, $this->getServerEncoding());
                 }
-                if (isset($mail->sender) and !empty($mail->sender)) {
+                if (isset($mail->sender) and !empty(trim($mail->sender))) {
                     $mail->sender = $this->decodeMimeStr($mail->sender, $this->getServerEncoding());
                 }
-                if (isset($mail->to)) {
+                if (isset($mail->to) and !empty(trim($mail->to))) {
                     $mail->to = $this->decodeMimeStr($mail->to, $this->getServerEncoding());
                 }
             }
@@ -896,32 +896,32 @@ class Mailbox
         $header->precedence = (preg_match("/Precedence\:(.*)/i", $headersRaw, $matches)) ? trim($matches[1]) : '';
         $header->failedRecipients = (preg_match("/Failed-Recipients\:(.*)/i", $headersRaw, $matches)) ? trim($matches[1]) : '';
 
-        if (isset($head->date) and !empty($head->date)) {
+        if (isset($head->date) and !empty(trim($head->date))) {
             $header->date = self::parseDateTime($head->date);
-        } elseif (isset($head->Date) and !empty($head->Date)) {
+        } elseif (isset($head->Date) and !empty(trim($head->Date))) {
             $header->date = self::parseDateTime($head->Date);
         } else {
             $now = new DateTime();
             $header->date = self::parseDateTime($now->format('Y-m-d H:i:s'));
         }
 
-        $header->subject = (isset($head->subject) and !empty($head->subject)) ? $this->decodeMimeStr($head->subject, $this->getServerEncoding()) : null;
-        if (isset($head->from) and !empty($head->from)) {
+        $header->subject = (isset($head->subject) and !empty(trim($head->subject))) ? $this->decodeMimeStr($head->subject, $this->getServerEncoding()) : null;
+        if (isset($head->from) and !empty(trim($head->from))) {
             $header->fromHost = isset($head->from[0]->host) ? $head->from[0]->host : (isset($head->from[1]->host) ? $head->from[1]->host : null);
-            $header->fromName = (isset($head->from[0]->personal) and !empty($head->from[0]->personal)) ? $this->decodeMimeStr($head->from[0]->personal, $this->getServerEncoding()) : ((isset($head->from[1]->personal) and (!empty($head->from[1]->personal))) ? $this->decodeMimeStr($head->from[1]->personal, $this->getServerEncoding()) : null);
+            $header->fromName = (isset($head->from[0]->personal) and !empty(trim($head->from[0]->personal))) ? $this->decodeMimeStr($head->from[0]->personal, $this->getServerEncoding()) : ((isset($head->from[1]->personal) and (!empty(trim($head->from[1]->personal)))) ? $this->decodeMimeStr($head->from[1]->personal, $this->getServerEncoding()) : null);
             $header->fromAddress = strtolower($head->from[0]->mailbox.'@'.$header->fromHost);
         } elseif (preg_match('/smtp.mailfrom=[-0-9a-zA-Z.+_]+@[-0-9a-zA-Z.+_]+.[a-zA-Z]{2,4}/', $headersRaw, $matches)) {
             $header->fromAddress = substr($matches[0], 14);
         }
-        if (isset($head->sender) and !empty($head->sender)) {
+        if (isset($head->sender) and !empty(trim($head->sender))) {
             $header->senderHost = isset($head->sender[0]->host) ? $head->sender[0]->host : (isset($head->sender[1]->host) ? $head->sender[1]->host : null);
-            $header->senderName = (isset($head->sender[0]->personal) and !empty($head->sender[0]->personal)) ? $this->decodeMimeStr($head->sender[0]->personal, $this->getServerEncoding()) : ((isset($head->sender[1]->personal) and (!empty($head->sender[1]->personal))) ? $this->decodeMimeStr($head->sender[1]->personal, $this->getServerEncoding()) : null);
+            $header->senderName = (isset($head->sender[0]->personal) and !empty(trim($head->sender[0]->personal))) ? $this->decodeMimeStr($head->sender[0]->personal, $this->getServerEncoding()) : ((isset($head->sender[1]->personal) and (!empty(trim($head->sender[1]->personal)))) ? $this->decodeMimeStr($head->sender[1]->personal, $this->getServerEncoding()) : null);
             $header->senderAddress = strtolower($head->sender[0]->mailbox.'@'.$header->senderHost);
         }
         if (isset($head->to)) {
             $toStrings = [];
             foreach ($head->to as $to) {
-                if (!empty($to->mailbox) && !empty($to->host)) {
+                if (!empty($to->mailbox) && !empty(trim($to->host))) {
                     $toEmail = strtolower($to->mailbox.'@'.$to->host);
                     $toName = (isset($to->personal) and !empty(trim($to->personal))) ? $this->decodeMimeStr($to->personal, $this->getServerEncoding()) : null;
                     $toStrings[] = $toName ? "$toName <$toEmail>" : $toEmail;
@@ -933,7 +933,7 @@ class Mailbox
 
         if (isset($head->cc)) {
             foreach ($head->cc as $cc) {
-                if (!empty($cc->mailbox) && !empty($cc->host)) {
+                if (!empty(trim($cc->mailbox)) && !empty(trim($cc->host))) {
                     $ccEmail = strtolower($cc->mailbox.'@'.$cc->host);
                     $ccName = (isset($cc->personal) and !empty(trim($cc->personal))) ? $this->decodeMimeStr($cc->personal, $this->getServerEncoding()) : null;
                     $ccStrings[] = $ccName ? "$ccName <$ccEmail>" : $ccEmail;
@@ -944,7 +944,7 @@ class Mailbox
 
         if (isset($head->bcc)) {
             foreach ($head->bcc as $bcc) {
-                if (!empty($bcc->mailbox) && !empty($bcc->host)) {
+                if (!empty(trim($bcc->mailbox)) && !empty(trim($bcc->host))) {
                     $bccEmail = strtolower($bcc->mailbox.'@'.$bcc->host);
                     $bccName = (isset($bcc->personal) and !empty(trim($bcc->personal))) ? $this->decodeMimeStr($bcc->personal, $this->getServerEncoding()) : null;
                     $bccStrings[] = $bccName ? "$bccName <$bccEmail>" : $bccEmail;
@@ -955,7 +955,7 @@ class Mailbox
 
         if (isset($head->reply_to)) {
             foreach ($head->reply_to as $replyTo) {
-                if (!empty($replyTo->mailbox) && !empty($replyTo->host)) {
+                if (!empty(trim($replyTo->mailbox)) && !empty(trim($replyTo->host))) {
                     $replyToEmail = strtolower($replyTo->mailbox.'@'.$replyTo->host);
                     $replyToName = (isset($replyTo->personal) and !empty(trim($replyTo->personal))) ? $this->decodeMimeStr($replyTo->personal, $this->getServerEncoding()) : null;
                     $replyToStrings[] = $replyToName ? "$replyToName <$replyToEmail>" : $replyToEmail;
@@ -1032,7 +1032,7 @@ class Mailbox
         $params = [];
         if (!empty($partStructure->parameters)) {
             foreach ($partStructure->parameters as $param) {
-                $params[strtolower($param->attribute)] = (!isset($param->value) || empty($param->value)) ? '' : $this->decodeMimeStr($param->value);
+                $params[strtolower($param->attribute)] = (!isset($param->value) || empty(trim($param->value))) ? '' : $this->decodeMimeStr($param->value);
             }
         }
         if (!empty($partStructure->dparameters)) {
@@ -1082,7 +1082,7 @@ class Mailbox
             $attachment = self::downloadAttachment($dataInfo, $params, $partStructure, $mail->id, $emlParse);
             $mail->addAttachment($attachment);
         } else {
-            if (!empty($params['charset'])) {
+            if (!empty(trim($params['charset']))) {
                 $dataInfo->charset = $params['charset'];
             }
         }
@@ -1131,10 +1131,10 @@ class Mailbox
             $fileExt = strtolower($partStructure->subtype).'.eml';
         } elseif ('ALTERNATIVE' == $partStructure->subtype) {
             $fileExt = strtolower($partStructure->subtype).'.eml';
-        } elseif (empty($params['filename']) && empty($params['name'])) {
+        } elseif (empty(trim($params['filename'])) && empty(trim($params['name']))) {
             $fileExt = strtolower($partStructure->subtype);
         } else {
-            $fileName = !empty($params['filename']) ? $params['filename'] : $params['name'];
+            $fileName = !empty(trim($params['filename'])) ? $params['filename'] : $params['name'];
             $fileName = $this->decodeMimeStr($fileName, $this->getServerEncoding());
             $fileName = $this->decodeRFC2231($fileName, $this->getServerEncoding());
         }
@@ -1155,7 +1155,7 @@ class Mailbox
         $attachment->name = $fileName;
         $attachment->emlOrigin = $emlOrigin;
         $attachment->disposition = (isset($partStructure->disposition) ? $partStructure->disposition : null);
-        $attachment->charset = (isset($params['charset']) and !empty($params['charset'])) ? $params['charset'] : null;
+        $attachment->charset = (isset($params['charset']) and !empty(trim($params['charset']))) ? $params['charset'] : null;
         if (null != $this->getAttachmentsDir()) {
             $replace = [
                 '/\s/' => '_',
@@ -1237,7 +1237,7 @@ class Mailbox
      */
     public function parseDateTime($dateHeader)
     {
-        if (empty($dateHeader)) {
+        if (empty(trim($dateHeader))) {
             throw new InvalidParameterException('parseDateTime() expects parameter 1 to be a parsable string datetime');
         }
 
@@ -1466,7 +1466,7 @@ class Mailbox
      */
     protected function getCombinedPath($folder, $absolute = false)
     {
-        if (empty($folder)) {
+        if (empty(trim($folder))) {
             return $this->imapPath;
         } elseif ('}' === substr($this->imapPath, -1)) {
             return $this->imapPath.$folder;

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1153,9 +1153,10 @@ class Mailbox
         $attachment->id = $attachmentId;
         $attachment->contentId = $partStructure->ifid ? trim($partStructure->id, ' <>') : null;
         $attachment->name = $fileName;
-        $attachment->emlOrigin = $emlOrigin;
         $attachment->disposition = (isset($partStructure->disposition) ? $partStructure->disposition : null);
         $attachment->charset = (isset($params['charset']) and !empty(trim($params['charset']))) ? $params['charset'] : null;
+        $attachment->emlOrigin = $emlOrigin;
+
         if (null != $this->getAttachmentsDir()) {
             $replace = [
                 '/\s/' => '_',

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1297,7 +1297,7 @@ class Mailbox
     }
 
     /**
-     * Gets imappath.
+     * Gets IMAP path.
      *
      * @return string
      */

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1105,7 +1105,9 @@ class Mailbox
             if (TYPETEXT === $partStructure->type) {
                 if ('plain' == strtolower($partStructure->subtype)) {
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_PLAIN);
-                } else {
+                } elseif (! $partStructure->ifdisposition) {
+                    $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_HTML);
+                } elseif ('attachment' != strtolower($partStructure->disposition)) {
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_HTML);
                 }
             } elseif (TYPEMESSAGE === $partStructure->type) {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -906,14 +906,14 @@ class Mailbox
         }
 
         $header->subject = (isset($head->subject) and !empty(trim($head->subject))) ? $this->decodeMimeStr($head->subject, $this->getServerEncoding()) : null;
-        if (isset($head->from) and !empty(trim($head->from))) {
+        if (isset($head->from) and !empty($head->from)) {
             $header->fromHost = isset($head->from[0]->host) ? $head->from[0]->host : (isset($head->from[1]->host) ? $head->from[1]->host : null);
             $header->fromName = (isset($head->from[0]->personal) and !empty(trim($head->from[0]->personal))) ? $this->decodeMimeStr($head->from[0]->personal, $this->getServerEncoding()) : ((isset($head->from[1]->personal) and (!empty(trim($head->from[1]->personal)))) ? $this->decodeMimeStr($head->from[1]->personal, $this->getServerEncoding()) : null);
             $header->fromAddress = strtolower($head->from[0]->mailbox.'@'.$header->fromHost);
         } elseif (preg_match('/smtp.mailfrom=[-0-9a-zA-Z.+_]+@[-0-9a-zA-Z.+_]+.[a-zA-Z]{2,4}/', $headersRaw, $matches)) {
             $header->fromAddress = substr($matches[0], 14);
         }
-        if (isset($head->sender) and !empty(trim($head->sender))) {
+        if (isset($head->sender) and !empty($head->sender)) {
             $header->senderHost = isset($head->sender[0]->host) ? $head->sender[0]->host : (isset($head->sender[1]->host) ? $head->sender[1]->host : null);
             $header->senderName = (isset($head->sender[0]->personal) and !empty(trim($head->sender[0]->personal))) ? $this->decodeMimeStr($head->sender[0]->personal, $this->getServerEncoding()) : ((isset($head->sender[1]->personal) and (!empty(trim($head->sender[1]->personal)))) ? $this->decodeMimeStr($head->sender[1]->personal, $this->getServerEncoding()) : null);
             $header->senderAddress = strtolower($head->sender[0]->mailbox.'@'.$header->senderHost);
@@ -1082,7 +1082,7 @@ class Mailbox
             $attachment = self::downloadAttachment($dataInfo, $params, $partStructure, $mail->id, $emlParse);
             $mail->addAttachment($attachment);
         } else {
-            if (!empty(trim($params['charset']))) {
+            if (isset($params['charset']) AND !empty(trim($params['charset']))) {
                 $dataInfo->charset = $params['charset'];
             }
         }
@@ -1131,10 +1131,10 @@ class Mailbox
             $fileExt = strtolower($partStructure->subtype).'.eml';
         } elseif ('ALTERNATIVE' == $partStructure->subtype) {
             $fileExt = strtolower($partStructure->subtype).'.eml';
-        } elseif (empty(trim($params['filename'])) && empty(trim($params['name']))) {
+        } elseif (!isset($params['filename']) OR empty(trim($params['filename'])) && (!isset($params['name']) OR empty(trim($params['name'])))) {
             $fileExt = strtolower($partStructure->subtype);
         } else {
-            $fileName = !empty(trim($params['filename'])) ? $params['filename'] : $params['name'];
+            $fileName = (isset($params['filename']) AND !empty(trim($params['filename']))) ? $params['filename'] : $params['name'];
             $fileName = $this->decodeMimeStr($fileName, $this->getServerEncoding());
             $fileName = $this->decodeRFC2231($fileName, $this->getServerEncoding());
         }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1264,8 +1264,6 @@ class Mailbox
      * @param string $toEncoding   the new charset (encoding)
      *
      * @return string Converted string if conversion was successful, or the original string if not
-     *
-     * @throws Exception
      */
     public function convertStringEncoding($string, $fromEncoding, $toEncoding)
     {
@@ -1282,11 +1280,8 @@ class Mailbox
             $convertedString = mb_convert_encoding($string, $toEncoding, $fromEncoding);
         } elseif (\function_exists('iconv')) {
             $convertedString = @iconv($fromEncoding, $toEncoding.'//TRANSLIT//IGNORE', $string);
-            if (false === $convertedString) {
-                throw new Exception('Mime string encoding conversion failed');
-            }
         }
-        if ('' == $convertedString) {
+        if (('' == $convertedString) OR (false === $convertedString)) {
             return $string;
         }
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1157,6 +1157,8 @@ class Mailbox
         $attachment->charset = (isset($params['charset']) and !empty(trim($params['charset']))) ? $params['charset'] : null;
         $attachment->emlOrigin = $emlOrigin;
 
+        $attachment->addDataPartInfo($dataInfo);
+
         if (null != $this->getAttachmentsDir()) {
             $replace = [
                 '/\s/' => '_',
@@ -1172,7 +1174,6 @@ class Mailbox
                 $filePath = substr($filePath, 0, 255 - 1 - \strlen($ext)).'.'.$ext;
             }
             $attachment->setFilePath($filePath);
-            $attachment->addDataPartInfo($dataInfo);
             $attachment->saveToDisk();
         }
 


### PR DESCRIPTION
- Issue #390: Fixed, that attached HTML files got merged into the `textHtml` property
- Issue #397: `convertStringEncoding()` will now always return a string and never throw an exception
- Issue #398: Fixed issue, that files could not be manually (one by one) saved to disk using `saveToDisk()`
- Issue #400: Fixed issue, that `empty()` returned a wrong result for strings with only whitespaces
- Updated some PhpDoc comment-blocks
- Improved code of `DataPartInfo` to be more human-readable
- Removed wrong `if`-condition in `DataPartInfo::fetch()`
- Fixed a few PhpCS warnings (eg. `Expected type X, but Y given`)
- Resorted $attachment property assignments based on IncomingMailAttachment properties order
