### PR TITLE
snaphsot no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 before_script:
   - composer install --no-interaction


### PR DESCRIPTION
should ensure travis runs a stable version of php 7.4