### PR TITLE
adding a .editorconfig file to avoid tab indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+ident_size = 2


### PR DESCRIPTION
inadvertently created a tab-indented file when creating #419 