### PR TITLE
further static analysis with psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "ext-fileinfo": "*",
         "friendsofphp/php-cs-fixer": "^2.16",
-        "ext-fileinfo": "*"
+        "phpunit/phpunit": "^5.7"
     },
     "suggest": {
         "ext-fileinfo": "To facilitate IncomingMailAttachment::getMimeType() auto-detection"

--- a/examples/get_and_parse_all_emails_with_matching_subject.php
+++ b/examples/get_and_parse_all_emails_with_matching_subject.php
@@ -33,11 +33,11 @@
             false // Do NOT mark emails as seen (optional)
         );
 
-        echo 'from-name: '.(isset($email->fromName)) ? $email->fromName : $email->fromAddress."\n";
-        echo 'from-email: '.$email->fromAddress."\n";
-        echo 'to: '.$email->to."\n";
-        echo 'subject: '.$email->subject."\n";
-        echo 'message_id: '.$email->messageId."\n";
+        echo 'from-name: '.(string) (isset($email->fromName) ? $email->fromName : $email->fromAddress)."\n";
+        echo 'from-email: '.(string) $email->fromAddress."\n";
+        echo 'to: '.(string) $email->toString."\n";
+        echo 'subject: '.(string) $email->subject."\n";
+        echo 'message_id: '.(string) $email->messageId."\n";
 
         echo 'mail has attachments? ';
         if ($email->hasAttachments()) {

--- a/examples/get_and_parse_all_emails_without_saving_attachments.php
+++ b/examples/get_and_parse_all_emails_without_saving_attachments.php
@@ -43,11 +43,11 @@
             false // Do NOT mark emails as seen (optional)
         );
 
-        echo 'from-name: '.(isset($email->fromName)) ? $email->fromName : $email->fromAddress."\n";
-        echo 'from-email: '.$email->fromAddress."\n";
-        echo 'to: '.$email->to."\n";
-        echo 'subject: '.$email->subject."\n";
-        echo 'message_id: '.$email->messageId."\n";
+        echo 'from-name: '.(string) (isset($email->fromName) ? $email->fromName : $email->fromAddress)."\n";
+        echo 'from-email: '.(string) $email->fromAddress."\n";
+        echo 'to: '.(string) $email->toString."\n";
+        echo 'subject: '.(string) $email->subject."\n";
+        echo 'message_id: '.(string) $email->messageId."\n";
 
         echo 'mail has attachments? ';
         if ($email->hasAttachments()) {

--- a/examples/get_and_parse_unseen_emails.php
+++ b/examples/get_and_parse_unseen_emails.php
@@ -33,11 +33,11 @@
             false // Do NOT mark emails as seen (optional)
         );
 
-        echo 'from-name: '.(isset($email->fromName)) ? $email->fromName : $email->fromAddress."\n";
-        echo 'from-email: '.$email->fromAddress."\n";
-        echo 'to: '.$email->to."\n";
-        echo 'subject: '.$email->subject."\n";
-        echo 'message_id: '.$email->messageId."\n";
+        echo 'from-name: '.(string) (isset($email->fromName) ? $email->fromName : $email->fromAddress)."\n";
+        echo 'from-email: '.(string) $email->fromAddress."\n";
+        echo 'to: '.(string) $email->toString."\n";
+        echo 'subject: '.(string) $email->subject."\n";
+        echo 'message_id: '.(string) $email->messageId."\n";
 
         echo 'mail has attachments? ';
         if ($email->hasAttachments()) {

--- a/examples/get_and_parse_unseen_emails_save_attachments_one_by_one.php
+++ b/examples/get_and_parse_unseen_emails_save_attachments_one_by_one.php
@@ -31,11 +31,11 @@
             false // Do NOT mark emails as seen (optional)
         );
 
-        echo 'from-name: '.(isset($email->fromName)) ? $email->fromName : $email->fromAddress."\n";
-        echo 'from-email: '.$email->fromAddress."\n";
-        echo 'to: '.$email->to."\n";
-        echo 'subject: '.$email->subject."\n";
-        echo 'message_id: '.$email->messageId."\n";
+        echo 'from-name: '.(string) (isset($email->fromName) ? $email->fromName : $email->fromAddress)."\n";
+        echo 'from-email: '.(string) $email->fromAddress."\n";
+        echo 'to: '.(string) $email->toString."\n";
+        echo 'subject: '.(string) $email->subject."\n";
+        echo 'message_id: '.(string) $email->messageId."\n";
 
         echo 'mail has attachments? ';
         if ($email->hasAttachments()) {
@@ -49,11 +49,11 @@
         }
 
         // Save attachments one by one
-        if (!$mbox_connection->getAttachmentsIgnore()) {
-            $attachments = $email_content->getAttachments();
+        if (!$mailbox->getAttachmentsIgnore()) {
+            $attachments = $email->getAttachments();
 
             foreach ($attachments as $attachment) {
-                echo '--> Saving '.$attachment->name.'...';
+                echo '--> Saving '.(string) $attachment->name.'...';
 
                 // Set individually filePath for each single attachment
                 // In this case, every file will get the current Unix timestamp

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -105,7 +105,7 @@
       <code>$partStructure-&gt;ifid ? $partStructure-&gt;id : ''</code>
       <code>$t[0]-&gt;mailbox</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="20">
+    <MixedPropertyFetch occurrences="17">
       <code>$param-&gt;value</code>
       <code>$param-&gt;value</code>
       <code>$param-&gt;attribute</code>
@@ -118,9 +118,6 @@
       <code>$element-&gt;charset</code>
       <code>$element-&gt;charset</code>
       <code>$element-&gt;text</code>
-      <code>$item-&gt;name</code>
-      <code>$item-&gt;attributes</code>
-      <code>$item-&gt;delimiter</code>
       <code>$t[0]-&gt;host</code>
       <code>$t[1]-&gt;host</code>
       <code>$t[0]-&gt;personal</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -79,7 +79,7 @@
       <code>$t[1]-&gt;personal</code>
       <code>$t[1]-&gt;personal</code>
     </MixedArgument>
-    <MixedAssignment occurrences="12">
+    <MixedAssignment occurrences="11">
       <code>$value</code>
       <code>$to</code>
       <code>$cc</code>
@@ -91,7 +91,6 @@
       <code>$subPartStructure</code>
       <code>$fileName</code>
       <code>$attachment-&gt;disposition</code>
-      <code>$element</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="2">
       <code>string</code>
@@ -104,7 +103,7 @@
       <code>$partStructure-&gt;ifid ? $partStructure-&gt;id : ''</code>
       <code>$t[0]-&gt;mailbox</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="17">
+    <MixedPropertyFetch occurrences="12">
       <code>$param-&gt;value</code>
       <code>$param-&gt;value</code>
       <code>$param-&gt;attribute</code>
@@ -112,11 +111,6 @@
       <code>$param-&gt;attribute</code>
       <code>$param-&gt;value</code>
       <code>$param-&gt;value</code>
-      <code>$element-&gt;text</code>
-      <code>$element-&gt;charset</code>
-      <code>$element-&gt;charset</code>
-      <code>$element-&gt;charset</code>
-      <code>$element-&gt;text</code>
       <code>$t[0]-&gt;host</code>
       <code>$t[1]-&gt;host</code>
       <code>$t[0]-&gt;personal</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -19,9 +19,7 @@
       <code>\is_int($retriesNum)</code>
       <code>\is_resource($this-&gt;imapStream)</code>
     </DocblockTypeContradiction>
-    <InvalidScalarArgument occurrences="3">
-      <code>$mail-&gt;id</code>
-      <code>$mail-&gt;id</code>
+    <InvalidScalarArgument occurrences="1">
       <code>$option &amp;&amp; FT_PREFETCHTEXT</code>
     </InvalidScalarArgument>
     <MissingParamType occurrences="5">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -22,13 +22,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$option &amp;&amp; FT_PREFETCHTEXT</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="5">
-      <code>$str</code>
-      <code>$str</code>
-      <code>$mailId</code>
-      <code>$mailId</code>
-      <code>$mailId</code>
-    </MissingParamType>
     <MixedArgument occurrences="45">
       <code>$mail-&gt;subject</code>
       <code>$mail-&gt;subject</code>
@@ -87,10 +80,6 @@
       <code>$params[$paramName]</code>
       <code>$subPartStructure</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>string</code>
-      <code>string</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="5">
       <code>$params[$paramName]</code>
       <code>$subPartNum</code>
@@ -112,10 +101,6 @@
       <code>$t[1]-&gt;personal</code>
       <code>$t[0]-&gt;mailbox</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
-      <code>$str</code>
-      <code>$str</code>
-    </MixedReturnStatement>
     <PossiblyInvalidArgument occurrences="1">
       <code>$mailStructure</code>
     </PossiblyInvalidArgument>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -22,23 +22,7 @@
     <InvalidScalarArgument occurrences="1">
       <code>$option &amp;&amp; FT_PREFETCHTEXT</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="45">
-      <code>$mail-&gt;subject</code>
-      <code>$mail-&gt;subject</code>
-      <code>$mail-&gt;from</code>
-      <code>$mail-&gt;from</code>
-      <code>$mail-&gt;sender</code>
-      <code>$mail-&gt;sender</code>
-      <code>$mail-&gt;to</code>
-      <code>$mail-&gt;to</code>
-      <code>$head-&gt;date</code>
-      <code>$head-&gt;date</code>
-      <code>$head-&gt;Date</code>
-      <code>$head-&gt;Date</code>
-      <code>$head-&gt;subject</code>
-      <code>$head-&gt;subject</code>
-      <code>$head-&gt;from</code>
-      <code>$head-&gt;sender</code>
+    <MixedArgument occurrences="29">
       <code>$to</code>
       <code>$cc</code>
       <code>$bcc</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -31,7 +31,7 @@
       <code>$mailId</code>
       <code>$mailId</code>
     </MissingParamType>
-    <MixedArgument occurrences="48">
+    <MixedArgument occurrences="46">
       <code>$mail-&gt;subject</code>
       <code>$mail-&gt;subject</code>
       <code>$mail-&gt;from</code>
@@ -74,8 +74,6 @@
       <code>$partStructure-&gt;id</code>
       <code>$element-&gt;charset</code>
       <code>$element-&gt;text</code>
-      <code>$recipient-&gt;personal</code>
-      <code>$recipient-&gt;personal</code>
       <code>$t[0]-&gt;personal</code>
       <code>$t[0]-&gt;personal</code>
       <code>$t[1]-&gt;personal</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -79,7 +79,7 @@
       <code>$t[1]-&gt;personal</code>
       <code>$t[1]-&gt;personal</code>
     </MixedArgument>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="12">
       <code>$value</code>
       <code>$to</code>
       <code>$cc</code>
@@ -92,7 +92,6 @@
       <code>$fileName</code>
       <code>$attachment-&gt;disposition</code>
       <code>$element</code>
-      <code>$item</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="2">
       <code>string</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -31,7 +31,7 @@
       <code>$mailId</code>
       <code>$mailId</code>
     </MissingParamType>
-    <MixedArgument occurrences="46">
+    <MixedArgument occurrences="45">
       <code>$mail-&gt;subject</code>
       <code>$mail-&gt;subject</code>
       <code>$mail-&gt;from</code>
@@ -70,7 +70,6 @@
       <code>$params['name']</code>
       <code>$partStructure-&gt;subtype</code>
       <code>$params['filename']</code>
-      <code>$fileName</code>
       <code>$partStructure-&gt;id</code>
       <code>$element-&gt;charset</code>
       <code>$element-&gt;text</code>
@@ -79,7 +78,7 @@
       <code>$t[1]-&gt;personal</code>
       <code>$t[1]-&gt;personal</code>
     </MixedArgument>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="9">
       <code>$value</code>
       <code>$to</code>
       <code>$cc</code>
@@ -89,8 +88,6 @@
       <code>$param</code>
       <code>$params[$paramName]</code>
       <code>$subPartStructure</code>
-      <code>$fileName</code>
-      <code>$attachment-&gt;disposition</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="2">
       <code>string</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.8.3@389af1bfc739bfdff3f9e3dc7bd6499aee51a831">
+  <file src="examples/get_and_parse_all_emails_without_saving_attachments.php">
+    <UnusedVariable occurrences="1">
+      <code>$mailbox</code>
+    </UnusedVariable>
+  </file>
   <file src="src/PhpImap/IncomingMail.php">
     <PossiblyUnusedMethod occurrences="2">
       <code>replaceInternalLinks</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.8.3@389af1bfc739bfdff3f9e3dc7bd6499aee51a831">
   <file src="src/PhpImap/IncomingMail.php">
-    <PossiblyUnusedMethod occurrences="3">
-      <code>hasAttachments</code>
+    <PossiblyUnusedMethod occurrences="2">
       <code>replaceInternalLinks</code>
       <code>embedImageAttachments</code>
     </PossiblyUnusedMethod>
@@ -143,7 +142,7 @@
       <code>$t[0]</code>
       <code>$t[1]</code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUnusedMethod occurrences="38">
+    <PossiblyUnusedMethod occurrences="35">
       <code>setOAuthToken</code>
       <code>getOAuthToken</code>
       <code>setConnectionRetry</code>
@@ -156,12 +155,10 @@
       <code>renameMailbox</code>
       <code>statusMailbox</code>
       <code>getListingFolders</code>
-      <code>searchMailbox</code>
       <code>saveMail</code>
       <code>deleteMail</code>
       <code>moveMail</code>
       <code>copyMail</code>
-      <code>markMailAsRead</code>
       <code>markMailAsUnread</code>
       <code>markMailAsImportant</code>
       <code>markMailsAsRead</code>
@@ -175,7 +172,6 @@
       <code>getQuotaLimit</code>
       <code>getQuotaUsage</code>
       <code>getRawMail</code>
-      <code>getMail</code>
       <code>getImapPath</code>
       <code>getMailMboxFormat</code>
       <code>getMailboxes</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -31,7 +31,7 @@
       <code>$mailId</code>
       <code>$mailId</code>
     </MissingParamType>
-    <MixedArgument occurrences="50">
+    <MixedArgument occurrences="48">
       <code>$mail-&gt;subject</code>
       <code>$mail-&gt;subject</code>
       <code>$mail-&gt;from</code>
@@ -74,8 +74,6 @@
       <code>$partStructure-&gt;id</code>
       <code>$element-&gt;charset</code>
       <code>$element-&gt;text</code>
-      <code>$recipient-&gt;mailbox</code>
-      <code>$recipient-&gt;host</code>
       <code>$recipient-&gt;personal</code>
       <code>$recipient-&gt;personal</code>
       <code>$t[0]-&gt;personal</code>
@@ -102,13 +100,11 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="7">
+    <MixedOperand occurrences="5">
       <code>$params[$paramName]</code>
       <code>$subPartNum</code>
       <code>$subPartNum</code>
       <code>$partStructure-&gt;ifid ? $partStructure-&gt;id : ''</code>
-      <code>$recipient-&gt;mailbox</code>
-      <code>$recipient-&gt;host</code>
       <code>$t[0]-&gt;mailbox</code>
     </MixedOperand>
     <MixedPropertyFetch occurrences="20">

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,7 @@
         <file name="./.php_cs.dist"/>
         <directory name="src"/>
         <directory name="tests"/>
+        <directory name="examples"/>
         <ignoreFiles>
             <directory name="vendor"/>
         </ignoreFiles>

--- a/src/PhpImap/IncomingMailHeader.php
+++ b/src/PhpImap/IncomingMailHeader.php
@@ -9,7 +9,7 @@ namespace PhpImap;
  */
 class IncomingMailHeader
 {
-    /** @var int|string|null $id The IMAP message ID - not the "Message-ID:"-header of the email */
+    /** @var string|null $id The IMAP message ID - not the "Message-ID:"-header of the email */
     public $id;
 
     /** @var bool */

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1382,6 +1382,8 @@ class Mailbox
      * @return string Converted string if conversion was successful, or the original string if not
      *
      * @throws Exception
+     *
+     * @todo update implementation pending resolution of https://github.com/vimeo/psalm/issues/2619 & https://github.com/vimeo/psalm/issues/2620
      */
     public function decodeMimeStr($string, $toCharset = 'utf-8')
     {
@@ -1390,7 +1392,9 @@ class Mailbox
         }
 
         $newString = '';
-        foreach (imap_mime_header_decode($string) as $element) {
+        /** @var list<object> */
+        $elements = imap_mime_header_decode($string);
+        foreach ($elements as $element) {
             if (isset($element->text)) {
                 /** @var string */
                 $fromCharset = !isset($element->charset) ? 'iso-8859-1' : $element->charset;

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1677,7 +1677,7 @@ class Mailbox
      */
     protected function possiblyGetEmailAndNameFromRecipient(object $recipient)
     {
-        if (isset($recipient->mailbox) && !empty(trim($recipient->mailbox)) && isset($recipient->host) && !empty(trim($recipient->host))) {
+        if (isset($recipient->mailbox, $recipient->host) && '' !== trim($recipient->mailbox) && '' !== trim($recipient->host)) {
             $recipientEmail = strtolower($recipient->mailbox.'@'.$recipient->host);
             $recipientName = (isset($recipient->personal) and !empty(trim($recipient->personal))) ? $this->decodeMimeStr($recipient->personal, $this->getServerEncoding()) : null;
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1332,6 +1332,7 @@ class Mailbox
         } elseif ((!isset($params['filename']) or empty(trim($params['filename']))) && (!isset($params['name']) or empty(trim($params['name'])))) {
             $fileName = strtolower($partStructure->subtype);
         } else {
+            /** @var string */
             $fileName = (isset($params['filename']) and !empty(trim($params['filename']))) ? $params['filename'] : $params['name'];
             $fileName = $this->decodeMimeStr($fileName, $this->getServerEncoding());
             $fileName = $this->decodeRFC2231($fileName, $this->getServerEncoding());
@@ -1341,7 +1342,7 @@ class Mailbox
         $attachment->id = sha1($fileName.($partStructure->ifid ? $partStructure->id : ''));
         $attachment->contentId = $partStructure->ifid ? trim($partStructure->id, ' <>') : null;
         $attachment->name = $fileName;
-        $attachment->disposition = (isset($partStructure->disposition) ? $partStructure->disposition : null);
+        $attachment->disposition = (isset($partStructure->disposition) && \is_string($partStructure->disposition)) ? $partStructure->disposition : null;
         if (isset($params['charset']) && !\is_string($params['charset'])) {
             throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must specify charset as a string when specified!');
         }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1174,8 +1174,8 @@ class Mailbox
     /**
      * Get mail data.
      *
-     * @param string  $mailId     ID of the mail
-     * @param bool $markAsSeen Mark the email as seen, when set to true
+     * @param string $mailId     ID of the mail
+     * @param bool   $markAsSeen Mark the email as seen, when set to true
      *
      * @return IncomingMail
      */

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1537,8 +1537,12 @@ class Mailbox
      */
     public function getMailboxes($search = '*')
     {
-        /** @psalm-var (scalar|array|object|resource|null)[] */
-        $mailboxes = (array) imap_getmailboxes($this->getImapStream(), $this->imapPath, $search);
+        /** @psalm-var (scalar|array|object|resource|null)[]|false */
+        $mailboxes = imap_getmailboxes($this->getImapStream(), $this->imapPath, $search);
+
+        if (!\is_array($mailboxes)) {
+            throw new UnexpectedValueException('Call to imap_getmailboxes() with supplied arguments returned false, not array!');
+        }
 
         return $this->possiblyGetMailboxes($mailboxes);
     }
@@ -1552,8 +1556,12 @@ class Mailbox
      */
     public function getSubscribedMailboxes($search = '*')
     {
-        /** @psalm-var (scalar|array|object|resource|null)[] */
+        /** @psalm-var (scalar|array|object|resource|null)[]|false */
         $mailboxes = (array) imap_getsubscribed($this->getImapStream(), $this->imapPath, $search);
+
+        if (!\is_array($mailboxes)) {
+            throw new UnexpectedValueException('Call to imap_getmailboxes() with supplied arguments returned false, not array!');
+        }
 
         return $this->possiblyGetMailboxes($mailboxes);
     }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1684,15 +1684,20 @@ class Mailbox
             /** @var mixed */
             $recipientHost = $recipient->host;
 
+            /** @var mixed */
+            $recipientPersonal = isset($recipient->personal) ? $recipient->personal : null;
+
             if (!\is_string($recipientMailbox)) {
                 throw new UnexpectedValueException('mailbox was present on argument 1 passed to '.__METHOD__.'() but was not a string!');
             } elseif (!\is_string($recipientHost)) {
                 throw new UnexpectedValueException('host was present on argument 1 passed to '.__METHOD__.'() but was not a string!');
+            } elseif (null !== $recipientPersonal && !\is_string($recipientPersonal)) {
+                throw new UnexpectedValueException('personal was present on argument 1 passed to '.__METHOD__.'() but was not a string!');
             }
 
             if ('' !== trim($recipientMailbox) && '' !== trim($recipientHost)) {
                 $recipientEmail = strtolower($recipientMailbox.'@'.$recipientHost);
-                $recipientName = (isset($recipient->personal) and !empty(trim($recipient->personal))) ? $this->decodeMimeStr($recipient->personal, $this->getServerEncoding()) : null;
+                $recipientName = (\is_string($recipientPersonal) and '' !== trim($recipientPersonal)) ? $this->decodeMimeStr($recipientPersonal, $this->getServerEncoding()) : null;
 
                 return [
                     $recipientEmail,

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1713,12 +1713,22 @@ class Mailbox
      * @param array $t
      *
      * @return array
+     *
+     * @todo revisit implementation pending resolution of https://github.com/vimeo/psalm/issues/2619
      */
     protected function possiblyGetMailboxes($t)
     {
         $arr = [];
         if ($t) {
-            foreach ($t as $item) {
+            foreach ($t as $index => $item) {
+                if (!\is_object($item)) {
+                    throw new UnexpectedValueException('Index '.(string) $index.' of argument 1 passed to '.__METHOD__.'() corresponds to a non-object value, '.\gettype($item).' given!');
+                } elseif (!isset($item->name, $item->attributes, $item->delimiter)) {
+                    throw new UnexpectedValueException('The object at index '.(string) $index.' of argument 1 passed to '.__METHOD__.'() was missing one or more of the required properties "name", "attributes", "delimiter"!');
+                } elseif (!\is_string($item->name)) {
+                    throw new UnexpectedValueException('The object at index '.(string) $index.' of argument 1 passed to '.__METHOD__.'() has a non-string value for the name property!');
+                }
+
                 // https://github.com/barbushin/php-imap/issues/339
                 $name = $this->decodeStringFromUtf7ImapToUtf8($item->name);
                 $name_pos = strpos($name, '}');

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1316,7 +1316,7 @@ class Mailbox
      *
      * @param array  $params        Array of params of mail
      * @param object $partStructure Part of mail
-     * @param int    $mailId        ID of mail
+     * @param string $mailId        ID of mail
      * @param bool   $emlOrigin     True, if it indicates, that the attachment comes from an EML (mail) file
      *
      * @psalm-param array<string, mixed> $params

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -689,16 +689,16 @@ class Mailbox
      * @param string $criteria              See http://php.net/imap_search for a complete list of available criteria
      * @param bool   $disableServerEncoding Disables server encoding while searching for mails (can be useful on Exchange servers)
      *
-     * @return int[] mailsIds (or empty array)
+     * @return string[] mailsIds (or empty array)
      */
     public function searchMailbox($criteria = 'ALL', $disableServerEncoding = false)
     {
         if ($disableServerEncoding) {
-            /** @var int[] */
+            /** @var string[] */
             return $this->imap('search', [$criteria, $this->imapSearchOption]) ?: [];
         }
 
-        /** @var int[] */
+        /** @var string[] */
         return $this->imap('search', [$criteria, $this->imapSearchOption, $this->getServerEncoding()]) ?: [];
     }
 
@@ -1034,7 +1034,7 @@ class Mailbox
     /**
      * Get mail header.
      *
-     * @param int $mailId ID of the message
+     * @param string $mailId ID of the message
      *
      * @return IncomingMailHeader
      *
@@ -1174,7 +1174,7 @@ class Mailbox
     /**
      * Get mail data.
      *
-     * @param int  $mailId     ID of the mail
+     * @param string  $mailId     ID of the mail
      * @param bool $markAsSeen Mark the email as seen, when set to true
      *
      * @return IncomingMail

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1677,14 +1677,28 @@ class Mailbox
      */
     protected function possiblyGetEmailAndNameFromRecipient(object $recipient)
     {
-        if (isset($recipient->mailbox, $recipient->host) && '' !== trim($recipient->mailbox) && '' !== trim($recipient->host)) {
-            $recipientEmail = strtolower($recipient->mailbox.'@'.$recipient->host);
+        if (isset($recipient->mailbox, $recipient->host)) {
+            /** @var mixed */
+            $recipientMailbox = $recipient->mailbox;
+
+            /** @var mixed */
+            $recipientHost = $recipient->host;
+
+            if (!\is_string($recipientMailbox)) {
+                throw new UnexpectedValueException('mailbox was present on argument 1 passed to '.__METHOD__.'() but was not a string!');
+            } elseif (!\is_string($recipientHost)) {
+                throw new UnexpectedValueException('host was present on argument 1 passed to '.__METHOD__.'() but was not a string!');
+            }
+
+            if ('' !== trim($recipientMailbox) && '' !== trim($recipientHost)) {
+                $recipientEmail = strtolower($recipientMailbox.'@'.$recipientHost);
             $recipientName = (isset($recipient->personal) and !empty(trim($recipient->personal))) ? $this->decodeMimeStr($recipient->personal, $this->getServerEncoding()) : null;
 
             return [
                 $recipientEmail,
                 $recipientName,
             ];
+            }
         }
 
         return null;

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1692,12 +1692,12 @@ class Mailbox
 
             if ('' !== trim($recipientMailbox) && '' !== trim($recipientHost)) {
                 $recipientEmail = strtolower($recipientMailbox.'@'.$recipientHost);
-            $recipientName = (isset($recipient->personal) and !empty(trim($recipient->personal))) ? $this->decodeMimeStr($recipient->personal, $this->getServerEncoding()) : null;
+                $recipientName = (isset($recipient->personal) and !empty(trim($recipient->personal))) ? $this->decodeMimeStr($recipient->personal, $this->getServerEncoding()) : null;
 
-            return [
-                $recipientEmail,
-                $recipientName,
-            ];
+                return [
+                    $recipientEmail,
+                    $recipientName,
+                ];
             }
         }
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -464,7 +464,9 @@ class Mailbox
     /**
      * Returns the provided string in UTF7-IMAP encoded format.
      *
-     * @return string $str UTF-7 encoded string or same as before, when it's no string
+     * @param scalar|array|object|resource|null $str
+     *
+     * @return string $str UTF-7 encoded string
      */
     public function encodeStringToUtf7Imap($str)
     {
@@ -478,12 +480,13 @@ class Mailbox
             return $out;
         }
 
-        // Return $str as it is, when it is no string
-        return $str;
+        throw new InvalidArgumentException('Argument 1 passed to '.__METHOD__.'() must be a string!');
     }
 
     /**
      * Returns the provided string in UTF-8 encoded format.
+     *
+     * @param scalar|array|object|resource|null $str
      *
      * @return string $str UTF-7 encoded string or same as before, when it's no string
      *
@@ -501,8 +504,7 @@ class Mailbox
             return $out;
         }
 
-        // Return $str as it is, when it is no string
-        return $str;
+        throw new InvalidArgumentException('Argument 1 passed to '.__METHOD__.'() must be a string!');
     }
 
     /**
@@ -768,7 +770,9 @@ class Mailbox
     /**
      * Add the flag \Seen to a mail.
      *
-     * @param $mailId
+     * @param string $mailId
+     *
+     * @return void
      */
     public function markMailAsRead($mailId)
     {
@@ -778,7 +782,9 @@ class Mailbox
     /**
      * Remove the flag \Seen from a mail.
      *
-     * @param $mailId
+     * @param string $mailId
+     *
+     * @return void
      */
     public function markMailAsUnread($mailId)
     {
@@ -788,7 +794,9 @@ class Mailbox
     /**
      * Add the flag \Flagged to a mail.
      *
-     * @param $mailId
+     * @param string $mailId
+     *
+     * @return void
      */
     public function markMailAsImportant($mailId)
     {
@@ -1742,16 +1750,19 @@ class Mailbox
         $arr = [];
         if ($t) {
             foreach ($t as $index => $item) {
+                /** @var scalar|array|object|resource|null */
+                $item_name = \is_object($item) && isset($item->name) ? $item->name : null;
+
                 if (!\is_object($item)) {
                     throw new UnexpectedValueException('Index '.(string) $index.' of argument 1 passed to '.__METHOD__.'() corresponds to a non-object value, '.\gettype($item).' given!');
                 } elseif (!isset($item->name, $item->attributes, $item->delimiter)) {
                     throw new UnexpectedValueException('The object at index '.(string) $index.' of argument 1 passed to '.__METHOD__.'() was missing one or more of the required properties "name", "attributes", "delimiter"!');
-                } elseif (!\is_string($item->name)) {
+                } elseif (!\is_string($item_name)) {
                     throw new UnexpectedValueException('The object at index '.(string) $index.' of argument 1 passed to '.__METHOD__.'() has a non-string value for the name property!');
                 }
 
                 // https://github.com/barbushin/php-imap/issues/339
-                $name = $this->decodeStringFromUtf7ImapToUtf8($item->name);
+                $name = $this->decodeStringFromUtf7ImapToUtf8($item_name);
                 $name_pos = strpos($name, '}');
                 if (false === $name_pos) {
                     throw new UnexpectedValueException('Expected token "}" not found in subscription name!');

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1532,7 +1532,10 @@ class Mailbox
      */
     public function getMailboxes($search = '*')
     {
-        return $this->possiblyGetMailboxes(imap_getmailboxes($this->getImapStream(), $this->imapPath, $search));
+        /** @psalm-var (scalar|array|object|resource|null)[] */
+        $mailboxes = (array) imap_getmailboxes($this->getImapStream(), $this->imapPath, $search);
+
+        return $this->possiblyGetMailboxes($mailboxes);
     }
 
     /**
@@ -1544,7 +1547,10 @@ class Mailbox
      */
     public function getSubscribedMailboxes($search = '*')
     {
-        return $this->possiblyGetMailboxes(imap_getsubscribed($this->getImapStream(), $this->imapPath, $search));
+        /** @psalm-var (scalar|array|object|resource|null)[] */
+        $mailboxes = (array) imap_getsubscribed($this->getImapStream(), $this->imapPath, $search);
+
+        return $this->possiblyGetMailboxes($mailboxes);
     }
 
     /**
@@ -1711,6 +1717,8 @@ class Mailbox
 
     /**
      * @param array $t
+     *
+     * @psalm-param (scalar|array|object|resource|null)[] $t
      *
      * @return array
      *

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -689,16 +689,16 @@ class Mailbox
      * @param string $criteria              See http://php.net/imap_search for a complete list of available criteria
      * @param bool   $disableServerEncoding Disables server encoding while searching for mails (can be useful on Exchange servers)
      *
-     * @return array mailsIds (or empty array)
+     * @return int[] mailsIds (or empty array)
      */
     public function searchMailbox($criteria = 'ALL', $disableServerEncoding = false)
     {
         if ($disableServerEncoding) {
-            /** @var array */
+            /** @var int[] */
             return $this->imap('search', [$criteria, $this->imapSearchOption]) ?: [];
         }
 
-        /** @var array */
+        /** @var int[] */
         return $this->imap('search', [$criteria, $this->imapSearchOption, $this->getServerEncoding()]) ?: [];
     }
 


### PR DESCRIPTION
this PR includes #433 

In order to explain the proliferation of `mixed` and `scalar|array|object|resource|null`, I'm currently trying to avoid having code *rely* on psalm being in use (which would necessitate adding a conflict entry in composer.json).

example:

```php
function foo($s) {
    if (is_int($s)) {
        echo 'foo';
    }
}
```

If the preceding example were to have `@param int $s` in it's docblock, this would result in a [`RedundantConditionGivenDocblockType` issue being flagged](https://psalm.dev/r/71b8f0113c). While one *could* then add such an error to the baseline file, I find it preferable to remove entries over time rather than adding to them.