### PR TITLE
Modify/test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit && ./vendor/bin/psalm --show-info=false --shepherd; fi

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -604,13 +604,13 @@ class Mailbox
      *  Nmsgs - number of mails in the mailbox
      *  Recent - number of recent mails in the mailbox
      *
-     * @return stdClass
+     * @return stdClass|false
      *
      * @see    imap_check
      */
     public function checkMailbox()
     {
-        /** @var stdClass */
+        /** @var stdClass|false */
         return $this->imap('check');
     }
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Live Mailbox - PHPUnit tests.
+ *
+ * Runs tests on a live mailbox
+ *
+ * @author BAPCLTD-Marv
+ */
+use ParagonIE\HiddenString\HiddenString;
+use PhpImap\Mailbox;
+use PHPUnit\Framework\TestCase;
+
+class LiveMailboxTest extends TestCase
+{
+    const RANDOM_MAILBOX_SAMPLE_SIZE = 3;
+
+    /**
+     * Provides constructor arguments for a live mailbox.
+     *
+     * @return array
+     *
+     * @psalm-return array{0:HiddenString, 1:HiddenString, 2:HiddenString, 3:string, 4?:string}[]
+     *
+     * @todo drop php 5.6, add paragonie/hidden-string to require-dev
+     */
+    public function MailBoxProvider()
+    {
+        if (!class_exists(HiddenString::class)) {
+            $this->markTestSkipped('paragonie/hidden-string not installed!');
+
+            return [];
+        }
+
+        $sets = [];
+
+        $imapPath = getenv('PHPIMAP_IMAP_PATH');
+        $login = getenv('PHPIMAP_LOGIN');
+        $password = getenv('PHPIMAP_PASSWORD');
+
+        if (is_string($imapPath) && is_string($login) && is_string($password)) {
+            $sets['CI ENV'] = [new HiddenString($imapPath), new HiddenString($login), new HiddenString($password, true, true), sys_get_temp_dir()];
+        }
+
+        return $sets;
+    }
+
+    /**
+     * @dataProvider MailBoxProvider
+     *
+     * @param string $imapPath
+     * @param string $login
+     * @param string $attachmentsDir
+     * @param string $serverEncoding
+     */
+    public function testGetImapStream($imapPath, $login, HiddenString $password, $attachmentsDir, $serverEncoding = 'UTF-8')
+    {
+        $mailbox = new Mailbox($imapPath, $login, $password->getString(), $attachmentsDir, $serverEncoding);
+
+        /** @var Exception|null */
+        $exception = null;
+
+        try {
+            $this->assertTrue(is_resource($mailbox->getImapStream()));
+            $this->assertTrue($mailbox->hasImapStream());
+
+            $mailboxes = $mailbox->getMailboxes();
+            shuffle($mailboxes);
+
+            $mailboxes = array_values($mailboxes);
+
+            $limit = min(count($mailboxes), self::RANDOM_MAILBOX_SAMPLE_SIZE);
+
+            for ($i = 0; $i < $limit; ++$i) {
+                $this->assertTrue(is_array($mailboxes[$i]));
+                $this->assertTrue(isset($mailboxes[$i]['shortpath']));
+                $this->assertTrue(is_string($mailboxes[$i]['shortpath']));
+                $mailbox->switchMailbox($mailboxes[$i]['shortpath']);
+
+                $check = $mailbox->checkMailbox();
+
+                $this->assertTrue(is_object($check));
+
+                foreach ([
+                    'Date',
+                    'Driver',
+                    'Mailbox',
+                    'Nmsgs',
+                    'Recent',
+                ] as $expectedProperty) {
+                    $this->assertTrue(property_exists($check, $expectedProperty));
+                }
+
+                $this->assertTrue(is_string($check->Date), 'Date property of Mailbox::checkMailbox() result was not a string!');
+
+                $unix = strtotime($check->Date);
+
+                if (false === $unix && preg_match('/[+-]\d{1,2}:?\d{2} \([^\)]+\)$/', $check->Date)) {
+                    /** @var int */
+                    $pos = strrpos($check->Date, '(');
+
+                    // Although the date property is likely RFC2822-compliant, it will not be parsed by strtotime()
+                    $unix = strtotime(substr($check->Date, 0, $pos));
+                }
+
+                $this->assertTrue(is_int($unix), 'Date property of Mailbox::checkMailbox() result was not a valid date!');
+                $this->assertTrue(in_array($check->Driver, ['POP3', 'IMAP', 'NNTP', 'pop3', 'imap', 'nntp'], true), 'Driver property of Mailbox::checkMailbox() result was not of an expected value!');
+                $this->assertTrue(is_int($check->Nmsgs), 'Nmsgs property of Mailbox::checkMailbox() result was not of an expected type!');
+                $this->assertTrue(is_int($check->Recent), 'Recent property of Mailbox::checkMailbox() result was not of an expected type!');
+
+                $status = $mailbox->statusMailbox();
+
+                foreach ([
+                    'messages',
+                    'recent',
+                    'unseen',
+                    'uidnext',
+                    'uidvalidity',
+                ] as $expectedProperty) {
+                    $this->assertTrue(property_exists($status, $expectedProperty));
+                }
+
+                $this->assertSame($check->Nmsgs, $mailbox->countMails(), 'Mailbox::checkMailbox()->Nmsgs did not match Mailbox::countMails()!');
+            }
+        } catch (Exception $ex) {
+            $exception = $ex;
+        } finally {
+            $mailbox->disconnect();
+        }
+
+        if (null !== $exception) {
+            throw $exception;
+        }
+    }
+}

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -48,12 +48,10 @@ class LiveMailboxTest extends TestCase
     /**
      * @dataProvider MailBoxProvider
      *
-     * @param string $imapPath
-     * @param string $login
      * @param string $attachmentsDir
      * @param string $serverEncoding
      */
-    public function testGetImapStream($imapPath, $login, HiddenString $password, $attachmentsDir, $serverEncoding = 'UTF-8')
+    public function testGetImapStream(HiddenString $imapPath, HiddenString $login, HiddenString $password, $attachmentsDir, $serverEncoding = 'UTF-8')
     {
         $mailbox = new Mailbox($imapPath, $login, $password->getString(), $attachmentsDir, $serverEncoding);
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -53,7 +53,7 @@ class LiveMailboxTest extends TestCase
      */
     public function testGetImapStream(HiddenString $imapPath, HiddenString $login, HiddenString $password, $attachmentsDir, $serverEncoding = 'UTF-8')
     {
-        $mailbox = new Mailbox($imapPath, $login, $password->getString(), $attachmentsDir, $serverEncoding);
+        $mailbox = new Mailbox($imapPath->getString(), $login->getString(), $password->getString(), $attachmentsDir, $serverEncoding);
 
         /** @var Exception|null */
         $exception = null;

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -726,4 +726,57 @@ final class MailboxTest extends TestCase
         $this->mailbox->setServerEncoding($serverEncoding);
         $this->assertEquals($this->mailbox->decodeMimeStr($str, $this->mailbox->getServerEncoding()), $expectedStr);
     }
+
+    /**
+     * @return array
+     *
+     * @psalm-return list<array{0:string, 1:string, 2:class-string<\Exception>, 3:string}>
+     */
+    public function attachmentDirFailureProvider()
+    {
+        return [
+            [
+                __DIR__,
+                '',
+                InvalidParameterException::class,
+                'setAttachmentsDir() expects a string as first parameter!',
+            ],
+            [
+                __DIR__,
+                ' ',
+                InvalidParameterException::class,
+                'setAttachmentsDir() expects a string as first parameter!',
+            ],
+            [
+                __DIR__,
+                __FILE__,
+                InvalidParameterException::class,
+                'Directory "'.__FILE__.'" not found',
+            ],
+        ];
+    }
+
+    /**
+     * Test that setting the attachments directory fails when expected.
+     *
+     * @dataProvider attachmentDirFailureProvider
+     *
+     * @param string $initialDir
+     * @param string $attachmentsDir
+     * @param string $expectedException
+     * @param string $expectedExceptionMessage
+     *
+     * @psalm-param class-string<\Exception> $expectedException
+     */
+    public function testAttachmentDirFailure($initialDir, $attachmentsDir, $expectedException, $expectedExceptionMessage)
+    {
+        $mailbox = new Mailbox('', '', '', $initialDir);
+
+        $this->assertSame(trim($initialDir), $mailbox->getAttachmentsDir());
+
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $mailbox->setAttachmentsDir($attachmentsDir);
+    }
 }


### PR DESCRIPTION
* d1b0c86 is to avoid psalm complaining of a redundant check, as `imap_check()` can return false on failure.
* 90d61d9 just increases test coverage of setting the attachments directory
* 704a3c9 uses the env variables `PHPIMAP_IMAP_PATH`, `PHPIMAP_LOGIN`, and `PHPIMAP_PASSWORD` to allow travis to run tests on a live mailbox, with paragonie/hidden-string to stop failed tests form leaking the credentials.