### PR TITLE
request for setting diff mode to use the udiff format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit && ./vendor/bin/psalm --show-info=false --shepherd; fi
-  - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff -v
+  - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover


### PR DESCRIPTION
the default diff mode is [a little unwieldly](https://travis-ci.org/bapcltd-marv/php-imap/jobs/640816500), `--diff-format=udiff` doesn't print out the entire file with the changes.

p.s. travis build failure is fixed in #441 