### PR TITLE
Add/multi sender search

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -22,7 +22,7 @@
     <InvalidScalarArgument occurrences="1">
       <code>$option &amp;&amp; FT_PREFETCHTEXT</code>
     </InvalidScalarArgument>
-    <PossiblyUnusedMethod occurrences="30">
+    <PossiblyUnusedMethod occurrences="32">
       <code>setOAuthToken</code>
       <code>getOAuthToken</code>
       <code>setConnectionRetry</code>
@@ -32,6 +32,8 @@
       <code>deleteMailbox</code>
       <code>renameMailbox</code>
       <code>getListingFolders</code>
+      <code>searchMailboxFrom</code>
+      <code>searchMailboxFromDisableServerEncoding</code>
       <code>saveMail</code>
       <code>deleteMail</code>
       <code>moveMail</code>


### PR DESCRIPTION
[ext-imap won't let you `ALL FROM foo@example.com OR ALL FROM bar@example.com`](https://www.php.net/manual/en/function.imap-search.php#119148), so I've added some convenience methods.