### PR TITLE
enabling ordered class elements php-cs-fixer rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,7 +9,8 @@ return PhpCsFixer\Config::create()
         ],
         'ordered_imports' => true,
         'phpdoc_to_comment' => false,
-        'no_superfluous_phpdoc_tags' => true
+        'no_superfluous_phpdoc_tags' => true,
+        'ordered_class_elements' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/PhpImap/IncomingMail.php
+++ b/src/PhpImap/IncomingMail.php
@@ -37,26 +37,6 @@ class IncomingMail extends IncomingMailHeader
     /** @var string|null */
     private $textHtml;
 
-    /** @return void */
-    public function setHeader(IncomingMailHeader $header)
-    {
-        /** @psalm-var array<string, scalar|array|object|null> */
-        $array = get_object_vars($header);
-        foreach ($array as $property => $value) {
-            $this->$property = $value;
-        }
-    }
-
-    /**
-     * @param DataPartInfo::TEXT_PLAIN|DataPartInfo::TEXT_HTML $type
-     *
-     * @return void
-     */
-    public function addDataPartInfo(DataPartInfo $dataInfo, $type)
-    {
-        $this->dataInfo[$type][] = $dataInfo;
-    }
-
     /**
      * __get() is utilized for reading data from inaccessible (protected
      * or private) or non-existing properties.
@@ -101,7 +81,23 @@ class IncomingMail extends IncomingMailHeader
         return isset($this->$name);
     }
 
-    /** @return void */
+    public function setHeader(IncomingMailHeader $header)
+    {
+        /** @psalm-var array<string, scalar|array|object|null> */
+        $array = get_object_vars($header);
+        foreach ($array as $property => $value) {
+            $this->$property = $value;
+        }
+    }
+
+    /**
+     * @param DataPartInfo::TEXT_PLAIN|DataPartInfo::TEXT_HTML $type
+     */
+    public function addDataPartInfo(DataPartInfo $dataInfo, $type)
+    {
+        $this->dataInfo[$type][] = $dataInfo;
+    }
+
     public function addAttachment(IncomingMailAttachment $attachment)
     {
         if (!\is_string($attachment->id)) {


### PR DESCRIPTION
for purposes of expediency, I'm needing to add downstream features on the forked master branch, then pull them back into a develop-based branch.

this rule seems to placate some of the more confusing git diffs by applying a consistent order to the methods (it's a config option set in the preferred php-cs-fixer config used in the downstream fork).