### PR TITLE
separate imap class for handling imap_* functions

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -72,10 +72,15 @@
       <code>\is_int($argument)</code>
       <code>\is_bool($allow_sequence)</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1"/>
     <MixedReturnTypeCoercion occurrences="2">
       <code>$result</code>
       <code>array[]</code>
     </MixedReturnTypeCoercion>
+    <PossiblyNullArgument occurrences="2">
+      <code>null === $search_criteria ? null : self::encodeStringToUtf7Imap($search_criteria)</code>
+      <code>null === $charset ? null : self::encodeStringToUtf7Imap($charset)</code>
+    </PossiblyNullArgument>
   </file>
   <file src="src/PhpImap/IncomingMail.php">
     <PossiblyUnusedMethod occurrences="2">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -92,11 +92,10 @@
     </PropertyTypeCoercion>
   </file>
   <file src="src/PhpImap/Mailbox.php">
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction occurrences="3">
       <code>\in_array($imapSearchOption, $supported_options, true)</code>
       <code>\is_int($retriesNum)</code>
       <code>\in_array($key, $supported_params, true)</code>
-      <code>$imapStream</code>
     </DocblockTypeContradiction>
     <InvalidScalarArgument occurrences="1">
       <code>$option &amp;&amp; FT_PREFETCHTEXT</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -92,12 +92,11 @@
     </PropertyTypeCoercion>
   </file>
   <file src="src/PhpImap/Mailbox.php">
-    <DocblockTypeContradiction occurrences="5">
+    <DocblockTypeContradiction occurrences="4">
       <code>\in_array($imapSearchOption, $supported_options, true)</code>
       <code>\is_int($retriesNum)</code>
       <code>\in_array($key, $supported_params, true)</code>
       <code>$imapStream</code>
-      <code>\is_resource($this-&gt;imapStream)</code>
     </DocblockTypeContradiction>
     <InvalidScalarArgument occurrences="1">
       <code>$option &amp;&amp; FT_PREFETCHTEXT</code>
@@ -136,10 +135,9 @@
       <code>subscribeMailbox</code>
       <code>unsubscribeMailbox</code>
     </PossiblyUnusedMethod>
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType occurrences="2">
       <code>!\is_int($retriesNum) or $retriesNum &lt; 0</code>
       <code>\is_int($retriesNum)</code>
-      <code>!\is_resource($this-&gt;imapStream) || !imap_ping($this-&gt;imapStream)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/unit/MailboxTest.php">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -101,9 +101,6 @@
       <code>\is_int($retriesNum)</code>
       <code>\in_array($key, $supported_params, true)</code>
     </DocblockTypeContradiction>
-    <InvalidScalarArgument occurrences="1">
-      <code>$option &amp;&amp; FT_PREFETCHTEXT</code>
-    </InvalidScalarArgument>
     <PossiblyUnusedMethod occurrences="32">
       <code>setOAuthToken</code>
       <code>getOAuthToken</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -6,7 +6,7 @@
     </UnusedVariable>
   </file>
   <file src="src/PhpImap/Imap.php">
-    <DocblockTypeContradiction occurrences="64">
+    <DocblockTypeContradiction occurrences="68">
       <code>\is_int($msg_number)</code>
       <code>\is_int($options)</code>
       <code>\is_string($flag)</code>
@@ -24,6 +24,10 @@
       <code>\is_int($msg_number)</code>
       <code>\is_int($options)</code>
       <code>\is_string($quota_root)</code>
+      <code>\is_string($ref)</code>
+      <code>\is_string($pattern)</code>
+      <code>\is_string($ref)</code>
+      <code>\is_string($pattern)</code>
       <code>\is_string($ref)</code>
       <code>\is_string($pattern)</code>
       <code>\is_string($mailbox)</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -5,6 +5,11 @@
       <code>$mailbox</code>
     </UnusedVariable>
   </file>
+  <file src="src/PhpImap/Imap.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>\is_resource($maybe)</code>
+    </DocblockTypeContradiction>
+  </file>
   <file src="src/PhpImap/IncomingMail.php">
     <PossiblyUnusedMethod occurrences="2">
       <code>replaceInternalLinks</code>
@@ -16,7 +21,7 @@
   </file>
   <file src="src/PhpImap/Mailbox.php">
     <DocblockTypeContradiction occurrences="2">
-      <code>\is_int($retriesNum)</code>
+      <code>$imapStream</code>
       <code>\is_resource($this-&gt;imapStream)</code>
     </DocblockTypeContradiction>
     <InvalidScalarArgument occurrences="1">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -6,9 +6,76 @@
     </UnusedVariable>
   </file>
   <file src="src/PhpImap/Imap.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="64">
+      <code>\is_int($msg_number)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($flag)</code>
+      <code>\is_int($options)</code>
+      <code>\is_int($flag)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_int($options)</code>
+      <code>\is_int($msg_number)</code>
+      <code>\is_string($section)</code>
+      <code>\is_int($options)</code>
+      <code>\is_int($msg_number)</code>
+      <code>\is_int($options)</code>
+      <code>\is_int($msg_number)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($quota_root)</code>
+      <code>\is_string($ref)</code>
+      <code>\is_string($pattern)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_string($username)</code>
+      <code>\is_string($password)</code>
+      <code>\is_int($options)</code>
+      <code>\is_int($n_retries)</code>
+      <code>\is_string($old_mbox)</code>
+      <code>\is_string($new_mbox)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_int($options)</code>
+      <code>\is_int($n_retries)</code>
+      <code>\is_int($msg_number)</code>
+      <code>\is_string($part_number)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($criteria)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($charset)</code>
+      <code>null !== $charset &amp;&amp; !\is_string($charset)</code>
+      <code>\is_string($flag)</code>
+      <code>\is_int($options)</code>
+      <code>\is_int($criteria)</code>
+      <code>\is_bool($reverse)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($search_criteria)</code>
+      <code>null !== $search_criteria &amp;&amp; !\is_string($search_criteria)</code>
+      <code>\is_string($charset)</code>
+      <code>null !== $charset &amp;&amp; !\is_string($charset)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_int($options)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_int($timeout_type)</code>
+      <code>\is_int($timeout)</code>
+      <code>\is_string($mailbox)</code>
+      <code>\is_string($str)</code>
+      <code>\is_string($str)</code>
+      <code>\is_string($method)</code>
+      <code>\is_int($argument)</code>
       <code>\is_resource($maybe)</code>
+      <code>\is_string($method)</code>
+      <code>\is_string($method)</code>
+      <code>\is_int($argument)</code>
+      <code>\is_bool($allow_sequence)</code>
     </DocblockTypeContradiction>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$result</code>
+      <code>array[]</code>
+    </MixedReturnTypeCoercion>
   </file>
   <file src="src/PhpImap/IncomingMail.php">
     <PossiblyUnusedMethod occurrences="2">
@@ -20,7 +87,10 @@
     </PropertyTypeCoercion>
   </file>
   <file src="src/PhpImap/Mailbox.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="5">
+      <code>\in_array($imapSearchOption, $supported_options, true)</code>
+      <code>\is_int($retriesNum)</code>
+      <code>\in_array($key, $supported_params, true)</code>
       <code>$imapStream</code>
       <code>\is_resource($this-&gt;imapStream)</code>
     </DocblockTypeContradiction>
@@ -78,6 +148,9 @@
       <code>assertAttributeEquals</code>
       <code>assertAttributeEquals</code>
     </DeprecatedMethod>
+    <InvalidArgument occurrences="1">
+      <code>constant('ANYTHING')</code>
+    </InvalidArgument>
     <MethodSignatureMismatch occurrences="1">
       <code>public function setUp()</code>
     </MethodSignatureMismatch>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -6,7 +6,7 @@
     </UnusedVariable>
   </file>
   <file src="src/PhpImap/Imap.php">
-    <DocblockTypeContradiction occurrences="68">
+    <DocblockTypeContradiction occurrences="67">
       <code>\is_int($msg_number)</code>
       <code>\is_int($options)</code>
       <code>\is_string($flag)</code>
@@ -17,7 +17,6 @@
       <code>\is_string($mailbox)</code>
       <code>\is_int($options)</code>
       <code>\is_int($msg_number)</code>
-      <code>\is_string($section)</code>
       <code>\is_int($options)</code>
       <code>\is_int($msg_number)</code>
       <code>\is_int($options)</code>

--- a/src/PhpImap/DataPartInfo.php
+++ b/src/PhpImap/DataPartInfo.php
@@ -13,7 +13,7 @@ class DataPartInfo
     const TEXT_HTML = 1;
 
     /**
-     * @var string|int
+     * @var int
      *
      * @readonly
      */
@@ -30,7 +30,7 @@ class DataPartInfo
     public $charset;
 
     /**
-     * @var string|int
+     * @var 0|string
      *
      * @readonly
      */
@@ -54,10 +54,10 @@ class DataPartInfo
     private $data;
 
     /**
-     * @param string|int $id
-     * @param string|int $part
-     * @param int|mixed  $encoding
-     * @param int        $options
+     * @param int       $id
+     * @param 0|string  $part
+     * @param int|mixed $encoding
+     * @param int       $options
      */
     public function __construct(Mailbox $mail, $id, $part, $encoding, $options)
     {
@@ -73,12 +73,10 @@ class DataPartInfo
      */
     public function fetch()
     {
-        if (0 == $this->part) {
-            /** @var string */
-            $this->data = $this->mail->imap('body', [$this->id, $this->options]);
+        if (0 === $this->part) {
+            $this->data = Imap::body($this->mail->getImapStream(), $this->id, $this->options);
         } else {
-            /** @var string */
-            $this->data = $this->mail->imap('fetchbody', [$this->id, $this->part, $this->options]);
+            $this->data = Imap::fetchbody($this->mail->getImapStream(), $this->id, $this->part, $this->options);
         }
 
         switch ($this->encoding) {

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -711,6 +711,12 @@ final class Imap
         $result = imap_open($mailbox, $username, $password, $options, $n_retries, $params);
 
         if (!$result) {
+            $lastError = imap_last_error();
+
+            if ('' !== trim($lastError)) {
+                throw new UnexpectedValueException('IMAP error:'.$lastError);
+            }
+
             throw new UnexpectedValueException('Could not open mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_open'));
         }
 

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -1177,11 +1177,12 @@ final class Imap
     }
 
     /**
-     * @param string $method
+     * @param array|false $errors
+     * @param string      $method
      *
      * @return UnexpectedValueException
      */
-    private static function HandleErrors(array $errors, $method)
+    private static function HandleErrors($errors, $method)
     {
         if (!\is_string($method)) {
             throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($method).' given!');

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -718,6 +718,16 @@ final class Imap
     }
 
     /**
+     * @param resource|false $imap_stream
+     *
+     * @return bool
+     */
+    public static function ping($imap_stream)
+    {
+        return \is_resource($imap_stream) && imap_ping($imap_stream);
+    }
+
+    /**
      * @param false|resource $imap_stream
      * @param string         $old_mbox
      * @param string         $new_mbox

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -965,7 +965,17 @@ final class Imap
         }
 
         if (!$result) {
-            throw new UnexpectedValueException('Could not search mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_search'));
+            $errors = imap_errors();
+
+            if (false === $errors) {
+                /*
+                * if there were no errors then there were no matches,
+                *  rather than a failure to parse criteria.
+                */
+                return [];
+            }
+
+            throw new UnexpectedValueException('Could not search mailbox!', 0, self::HandleErrors($errors, 'imap_search'));
         }
 
         /** @psalm-var list<int> */

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -507,7 +507,7 @@ final class Imap
      *
      * @psalm-return list<string>
      */
-    public static function list($imap_stream, $ref, $pattern)
+    public static function listOfMailboxes($imap_stream, $ref, $pattern)
     {
         if (!\is_string($ref)) {
             throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($ref).' given!');

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -342,7 +342,7 @@ final class Imap
     /**
      * @param false|resource $imap_stream
      * @param int            $msg_number
-     * @param string         $section
+     * @param string|int     $section
      * @param int            $options
      *
      * @return string
@@ -368,7 +368,7 @@ final class Imap
         $result = imap_fetchbody(
             self::EnsureResource($imap_stream, __METHOD__, 1),
             $msg_number,
-            self::encodeStringToUtf7Imap($section),
+            self::encodeStringToUtf7Imap((string) $section),
             $options
         );
 

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -1,0 +1,1237 @@
+<?php
+/**
+ * @author Barbushin Sergey http://linkedin.com/in/barbushin
+ * @author BAPCLTD-Marv
+ */
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use const CL_EXPUNGE;
+use const IMAP_CLOSETIMEOUT;
+use const IMAP_OPENTIMEOUT;
+use const IMAP_READTIMEOUT;
+use const IMAP_WRITETIMEOUT;
+use InvalidArgumentException;
+use function mb_detect_encoding;
+use const NIL;
+use function preg_match;
+use const SORTARRIVAL;
+use const SORTCC;
+use const SORTDATE;
+use const SORTFROM;
+use const SORTSIZE;
+use const SORTSUBJECT;
+use const SORTTO;
+use UnexpectedValueException;
+
+/**
+ * @psalm-type PARTSTRUCTURE_PARAM = object{attribute:string, value?:string}
+ * @psalm-type PARTSTRUCTURE = object{
+ *  id?:string,
+ *  encoding:int|mixed,
+ *  partStructure:object[],
+ *  parameters:PARTSTRUCTURE_PARAM[],
+ *  dparameters:object{attribute:string, value:string}[],
+ *  parts:array<int, object{disposition?:string}>,
+ *  type:int,
+ *  subtype:string
+ * }
+ */
+final class Imap
+{
+    /** @psalm-var list<int> */
+    const SORT_CRITERIA = [
+        SORTARRIVAL,
+        SORTCC,
+        SORTDATE,
+        SORTFROM,
+        SORTSIZE,
+        SORTSUBJECT,
+        SORTTO,
+    ];
+
+    /** @psalm-var list<int> */
+    const TIMEOUT_TYPES = [
+        IMAP_CLOSETIMEOUT,
+        IMAP_OPENTIMEOUT,
+        IMAP_READTIMEOUT,
+        IMAP_WRITETIMEOUT,
+    ];
+
+    /** @psalm-var list<int> */
+    const CLOSE_FLAGS = [
+        0,
+        CL_EXPUNGE,
+    ];
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int            $msg_number
+     * @param int            $options
+     *
+     * @return string
+     */
+    public static function body(
+        $imap_stream,
+        $msg_number,
+        $options = 0
+    ) {
+        if (!\is_int($msg_number)) {
+            throw new \InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be an integer, '.\gettype($msg_number).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new \InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_body(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            $msg_number,
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not fetch message body from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_body'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     *
+     * @return object
+     */
+    public static function check($imap_stream)
+    {
+        imap_errors(); // flush errors
+
+        $result = imap_check(self::EnsureResource($imap_stream, __METHOD__, 1));
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not check imap mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_check'));
+        }
+
+        /** @var object */
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int|string     $sequence
+     * @param string         $flag
+     * @param int            $options
+     *
+     * @return true
+     */
+    public static function clearflag_full(
+        $imap_stream,
+        $sequence,
+        $flag,
+        $options = 0
+    ) {
+        if (!\is_string($flag)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be a string, '.\gettype($flag).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_clearflag_full(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            self::encodeStringToUtf7Imap(static::EnsureRange(
+                $sequence,
+                __METHOD__,
+                2,
+                true
+            )),
+            self::encodeStringToUtf7Imap($flag),
+            $options
+        );
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not clear flag on messages!', 0, self::HandleErrors(imap_errors(), 'imap_clearflag_full'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int            $flag
+     *
+     * @psalm-param value-of<self::CLOSE_FLAGS> $flag
+     * @psalm-param 0|32768 $flag
+     *
+     * @return true
+     */
+    public static function close($imap_stream, $flag = 0)
+    {
+        if (!\is_int($flag)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be an integer, '.\gettype($flag).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_close(self::EnsureResource($imap_stream, __METHOD__, 1), $flag);
+
+        if (false === $result) {
+            $message = 'Could not close imap connection';
+
+            if (CL_EXPUNGE === ($flag & CL_EXPUNGE)) {
+                $message .= ', messages may not have been expunged';
+            }
+
+            $message .= '!';
+            throw new UnexpectedValueException($message, 0, self::HandleErrors(imap_errors(), 'imap_close'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $mailbox
+     *
+     * @return true
+     */
+    public static function createmailbox($imap_stream, $mailbox)
+    {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($mailbox).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_createmailbox(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            static::encodeStringToUtf7Imap($mailbox)
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not create mailbox!', 0, self::HandleErrors(imap_errors(), 'createmailbox'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string|int     $msg_number
+     * @param int            $options
+     *
+     * @return true
+     */
+    public static function delete(
+        $imap_stream,
+        $msg_number,
+        $options = 0
+    ) {
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_delete(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            self::encodeStringToUtf7Imap(self::EnsureRange(
+                $msg_number,
+                __METHOD__,
+                1
+            )),
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not delete message from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_delete'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $mailbox
+     *
+     * @return true
+     */
+    public static function deletemailbox($imap_stream, $mailbox)
+    {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($mailbox).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_deletemailbox(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            static::encodeStringToUtf7Imap($mailbox)
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not delete mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_deletemailbox'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     *
+     * @return true
+     */
+    public static function expunge($imap_stream)
+    {
+        imap_errors(); // flush errors
+
+        $result = imap_expunge(
+            self::EnsureResource($imap_stream, __METHOD__, 1)
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not expunge messages from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_expunge'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int|string     $sequence
+     * @param int            $options
+     *
+     * @return object[]
+     *
+     * @psalm-return list<object>
+     */
+    public static function fetch_overview(
+        $imap_stream,
+        $sequence,
+        $options = 0
+    ) {
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_fetch_overview(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            self::encodeStringToUtf7Imap(self::EnsureRange(
+                $sequence,
+                __METHOD__,
+                1,
+                true
+            )),
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not fetch overview for message from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_fetch_overview'));
+        }
+
+        /** @psalm-var list<object> */
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int            $msg_number
+     * @param string         $section
+     * @param int            $options
+     *
+     * @return string
+     */
+    public static function fetchbody(
+        $imap_stream,
+        $msg_number,
+        $section,
+        $options = 0
+    ) {
+        if (!\is_int($msg_number)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be an integer, '.\gettype($msg_number).' given!');
+        }
+        if (!\is_string($section)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be a string, '.\gettype($section).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_fetchbody(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            $msg_number,
+            self::encodeStringToUtf7Imap($section),
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not fetch message body from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_fetchbody'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int            $msg_number
+     * @param int            $options
+     *
+     * @return string
+     */
+    public static function fetchheader(
+        $imap_stream,
+        $msg_number,
+        $options = 0
+    ) {
+        if (!\is_int($msg_number)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be an integer, '.\gettype($msg_number).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_fetchheader(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            $msg_number,
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not fetch message header from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_fetchheader'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int            $msg_number
+     * @param int            $options
+     *
+     * @return object
+     *
+     * @psalm-return PARTSTRUCTURE
+     */
+    public static function fetchstructure(
+        $imap_stream,
+        $msg_number,
+        $options = 0
+    ) {
+        if (!\is_int($msg_number)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be an integer, '.\gettype($msg_number).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_fetchstructure(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            $msg_number,
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not fetch message structure from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_fetchstructure'));
+        }
+
+        /** @psalm-var PARTSTRUCTURE */
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $quota_root
+     *
+     * @return array[]
+     */
+    public static function get_quotaroot(
+        $imap_stream,
+        $quota_root
+    ) {
+        if (!\is_string($quota_root)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($quota_root).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_get_quotaroot(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            self::encodeStringToUtf7Imap($quota_root)
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not quota for mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_get_quotaroot'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     *
+     * @return array
+     */
+    public static function headers($imap_stream)
+    {
+        imap_errors(); // flush errors
+
+        $result = imap_headers(
+            self::EnsureResource($imap_stream, __METHOD__, 1)
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not fetch headers from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_headers'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $ref
+     * @param string         $pattern
+     *
+     * @return string[]
+     *
+     * @psalm-return list<string>
+     */
+    public static function list($imap_stream, $ref, $pattern)
+    {
+        if (!\is_string($ref)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($ref).' given!');
+        }
+        if (!\is_string($pattern)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be a string, '.\gettype($pattern).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_list(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            static::encodeStringToUtf7Imap($ref),
+            static::encodeStringToUtf7Imap($pattern)
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not list folders mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_list'));
+        }
+
+        return array_values(array_map(
+            /**
+             * @param string $folder
+             *
+             * @return string
+             */
+            static function ($folder) {
+                return static::decodeStringFromUtf7ImapToUtf8($folder);
+            },
+            $result
+        ));
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int|string     $msglist
+     * @param string         $mailbox
+     * @param int            $options
+     *
+     * @return true
+     */
+    public static function mail_copy(
+        $imap_stream,
+        $msglist,
+        $mailbox,
+        $options = 0
+    ) {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be a string, '.\gettype($mailbox).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_mail_copy(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            static::encodeStringToUtf7Imap(self::EnsureRange(
+                $msglist,
+                __METHOD__,
+                2,
+                true
+            )),
+            static::encodeStringToUtf7Imap($mailbox),
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not copy messages!', 0, self::HandleErrors(imap_errors(), 'imap_mail_copy'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int|string     $msglist
+     * @param string         $mailbox
+     * @param int            $options
+     *
+     * @return true
+     */
+    public static function mail_move(
+        $imap_stream,
+        $msglist,
+        $mailbox,
+        $options = 0
+    ) {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be a string, '.\gettype($mailbox).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_mail_move(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            static::encodeStringToUtf7Imap(self::EnsureRange(
+                $msglist,
+                __METHOD__,
+                2,
+                true
+            )),
+            static::encodeStringToUtf7Imap($mailbox),
+            $options
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not move messages!', 0, self::HandleErrors(imap_errors(), 'imap_mail_move'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     *
+     * @return object
+     */
+    public static function mailboxmsginfo($imap_stream)
+    {
+        imap_errors(); // flush errors
+
+        $result = imap_mailboxmsginfo(
+            self::EnsureResource($imap_stream, __METHOD__, 1)
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not fetch mailboxmsginfo from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_mailboxmsginfo'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     *
+     * @return int
+     */
+    public static function num_msg($imap_stream)
+    {
+        imap_errors(); // flush errors
+
+        $result = imap_num_msg(self::EnsureResource($imap_stream, __METHOD__, 1));
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not get the number of messages in the mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_num_msg'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $mailbox
+     * @param string $username
+     * @param string $password
+     * @param int    $options
+     * @param int    $n_retries
+     *
+     * @psalm-param array{DISABLE_AUTHENTICATOR:string}|array<empty, empty> $params
+     *
+     * @return resource
+     */
+    public static function open(
+        $mailbox,
+        $username,
+        $password,
+        $options = 0,
+        $n_retries = 0,
+        array $params = []
+    ) {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 1 passed to '.__METHOD__.' must be a string, '.\gettype($mailbox).' given!');
+        }
+        if (!\is_string($username)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($username).' given!');
+        }
+        if (!\is_string($password)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be a string, '.\gettype($password).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+        if (!\is_int($n_retries)) {
+            throw new InvalidArgumentException('Argument 5 passed to '.__METHOD__.'() must be an integer, '.\gettype($n_retries).' given!');
+        }
+
+        if (preg_match("/^\{.*\}(.*)$/", $mailbox, $matches)) {
+            $mailbox_name = $matches[1];
+
+            if (!mb_detect_encoding($mailbox_name, 'ASCII', true)) {
+                $mailbox = static::encodeStringToUtf7Imap($mailbox_name);
+            }
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_open($mailbox, $username, $password, $options, $n_retries, $params);
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not open mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_open'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $old_mbox
+     * @param string         $new_mbox
+     *
+     * @return true
+     */
+    public static function renamemailbox(
+        $imap_stream,
+        $old_mbox,
+        $new_mbox
+    ) {
+        if (!\is_string($old_mbox)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($old_mbox).' given!');
+        }
+        if (!\is_string($new_mbox)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be a string, '.\gettype($new_mbox).' given!');
+        }
+
+        $imap_stream = self::EnsureResource($imap_stream, __METHOD__, 1);
+
+        $old_mbox = static::encodeStringToUtf7Imap($old_mbox);
+        $new_mbox = static::encodeStringToUtf7Imap($new_mbox);
+
+        imap_errors(); // flush errors
+
+        $result = imap_renamemailbox($imap_stream, $old_mbox, $new_mbox);
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not rename mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_renamemailbox'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $mailbox
+     * @param int            $options
+     * @param int            $n_retries
+     *
+     * @return true
+     */
+    public static function reopen(
+        $imap_stream,
+        $mailbox,
+        $options = 0,
+        $n_retries = 0
+    ) {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($mailbox).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be an integer, '.\gettype($options).' given!');
+        }
+        if (!\is_int($n_retries)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.' must be an integer, '.\gettype($n_retries).' given!');
+        }
+
+        $imap_stream = self::EnsureResource($imap_stream, __METHOD__, 1);
+
+        $mailbox = static::encodeStringToUtf7Imap($mailbox);
+
+        imap_errors(); // flush errors
+
+        $result = imap_reopen($imap_stream, $mailbox, $options, $n_retries);
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not reopen mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_reopen'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource        $imap_stream
+     * @param string|false|resource $file
+     * @param int                   $msg_number
+     * @param string                $part_number
+     * @param int                   $options
+     *
+     * @return true
+     */
+    public static function savebody(
+        $imap_stream,
+        $file,
+        $msg_number,
+        $part_number = '',
+        $options = 0
+    ) {
+        if (!\is_int($msg_number)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($msg_number).' given!');
+        }
+        if (!\is_string($part_number)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.'() must be an integer, '.\gettype($part_number).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 5 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        $imap_stream = self::EnsureResource($imap_stream, __METHOD__, 1);
+        $file = \is_string($file) ? $file : self::EnsureResource($file, __METHOD__, 2);
+        $part_number = self::encodeStringToUtf7Imap($part_number);
+
+        imap_errors(); // flush errors
+
+        $result = imap_savebody($imap_stream, $file, $msg_number, $part_number, $options);
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not reopen mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_savebody'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $criteria
+     * @param int            $options
+     * @param string         $charset
+     *
+     * @return int[]
+     *
+     * @psalm-return list<int>
+     */
+    public static function search(
+        $imap_stream,
+        $criteria,
+        $options = SE_FREE,
+        $charset = null
+    ) {
+        if (!\is_string($criteria)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($criteria).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be a string, '.\gettype($options).' given!');
+        }
+        if (null !== $charset && !\is_string($charset)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.' must be a string or null, '.\gettype($charset).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $imap_stream = static::EnsureResource($imap_stream, __METHOD__, 1);
+        $criteria = static::encodeStringToUtf7Imap($criteria);
+
+        if (\is_string($charset)) {
+            $result = imap_search(
+                $imap_stream,
+                $criteria,
+                $options,
+                static::encodeStringToUtf7Imap($charset)
+            );
+        } else {
+            $result = imap_search($imap_stream, $criteria, $options);
+        }
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not reopen mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_reopen'));
+        }
+
+        /** @psalm-var list<int> */
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int|string     $sequence
+     * @param string         $flag
+     * @param int            $options
+     *
+     * @return true
+     */
+    public static function setflag_full(
+        $imap_stream,
+        $sequence,
+        $flag,
+        $options = NIL
+    ) {
+        if (!\is_string($flag)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be a string, '.\gettype($flag).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.' must be an integer, '.\gettype($options).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_setflag_full(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            self::encodeStringToUtf7Imap(static::EnsureRange(
+                $sequence,
+                __METHOD__,
+                2,
+                true
+            )),
+            self::encodeStringToUtf7Imap($flag),
+            $options
+        );
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not set flag on messages!', 0, self::HandleErrors(imap_errors(), 'imap_setflag_full'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param int            $criteria
+     * @param bool           $reverse
+     * @param int            $options
+     * @param string|null    $search_criteria
+     * @param string|null    $charset
+     *
+     * @psalm-param value-of<self::SORT_CRITERIA> $criteria
+     * @psalm-param 1|5|0|2|6|3|4 $criteria
+     *
+     * @return int[]
+     *
+     * @psalm-return list<int>
+     */
+    public static function sort(
+        $imap_stream,
+        $criteria,
+        $reverse,
+        $options,
+        $search_criteria = null,
+        $charset = null
+    ) {
+        if (!\is_int($criteria)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be an integer, '.\gettype($criteria).' given!');
+        }
+        if (!\is_bool($reverse)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be a boolean, '.\gettype($reverse).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 4 passed to '.__METHOD__.' must be an integer, '.\gettype($options).' given!');
+        }
+        if (null !== $search_criteria && !\is_string($search_criteria)) {
+            throw new InvalidArgumentException('Argument 5 passed to '.__METHOD__.' must be a string or null, '.\gettype($search_criteria).' given!');
+        }
+        if (null !== $charset && !\is_string($charset)) {
+            throw new InvalidArgumentException('Argument 6 passed to '.__METHOD__.' must be a string or null, '.\gettype($charset).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_sort(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            $criteria,
+            (int) $reverse,
+            $options,
+            null === $search_criteria ? null : self::encodeStringToUtf7Imap($search_criteria),
+            null === $charset ? null : self::encodeStringToUtf7Imap($charset)
+        );
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not sort messages!', 0, self::HandleErrors(imap_errors(), 'imap_sort'));
+        }
+
+        /** @psalm-var list<int> */
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $mailbox
+     * @param int            $options
+     *
+     * @psalm-param SA_MESSAGES|SA_RECENT|SA_UNSEEN|SA_UIDNEXT|SA_UIDVALIDITY|SA_ALL $flags
+     *
+     * @return object
+     */
+    public static function status(
+        $imap_stream,
+        $mailbox,
+        $options
+    ) {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($mailbox).' given!');
+        }
+        if (!\is_int($options)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
+        }
+
+        $imap_stream = self::EnsureResource($imap_stream, __METHOD__, 1);
+
+        $mailbox = static::encodeStringToUtf7Imap($mailbox);
+
+        imap_errors(); // flush errors
+
+        $result = imap_status($imap_stream, $mailbox, $options);
+
+        if (!$result) {
+            throw new UnexpectedValueException('Could not get status of mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_status'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $mailbox
+     *
+     * @return void
+     */
+    public static function subscribe(
+        $imap_stream,
+        $mailbox
+    ) {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($mailbox).' given!');
+        }
+
+        $imap_stream = self::EnsureResource($imap_stream, __METHOD__, 1);
+
+        $mailbox = static::encodeStringToUtf7Imap($mailbox);
+
+        imap_errors(); // flush errors
+
+        $result = imap_subscribe($imap_stream, $mailbox);
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not subscribe to mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_subscribe'));
+        }
+    }
+
+    /**
+     * @param int $timeout_type
+     * @param int $timeout
+     *
+     * @psalm-param value-of<self::TIMEOUT_TYPES> $timeout_type
+     * @psalm-param 4|1|2|3 $timeout_type
+     *
+     * @return true|int
+     */
+    public static function timeout(
+        $timeout_type,
+        $timeout = -1
+    ) {
+        if (!\is_int($timeout_type)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be an integer, '.\gettype($timeout_type).' given!');
+        }
+        if (!\is_int($timeout)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($timeout).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_timeout(
+            $timeout_type,
+            $timeout
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not get/set connection timeout!', 0, self::HandleErrors(imap_errors(), 'imap_timeout'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param false|resource $imap_stream
+     * @param string         $mailbox
+     *
+     * @return void
+     */
+    public static function unsubscribe(
+        $imap_stream,
+        $mailbox
+    ) {
+        if (!\is_string($mailbox)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($mailbox).' given!');
+        }
+
+        $imap_stream = self::EnsureResource($imap_stream, __METHOD__, 1);
+
+        $mailbox = static::encodeStringToUtf7Imap($mailbox);
+
+        imap_errors(); // flush errors
+
+        $result = imap_unsubscribe($imap_stream, $mailbox);
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Could not unsubscribe from mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_unsubscribe'));
+        }
+    }
+
+    /**
+     * Returns the provided string in UTF7-IMAP encoded format.
+     *
+     * @param string $str
+     *
+     * @return string $str UTF-7 encoded string
+     */
+    public static function encodeStringToUtf7Imap($str)
+    {
+        if (!\is_string($str)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($str).' given!');
+        }
+
+        $out = mb_convert_encoding($str, 'UTF7-IMAP', mb_detect_encoding($str, 'UTF-8, ISO-8859-1, ISO-8859-15', true));
+
+        if (!\is_string($out)) {
+            throw new UnexpectedValueException('mb_convert_encoding($str, \'UTF-8\', {detected}) could not convert $str');
+        }
+
+        return $out;
+    }
+
+    /**
+     * Returns the provided string in UTF-8 encoded format.
+     *
+     * @param string $str
+     *
+     * @return string $str, but UTF-8 encoded
+     */
+    public static function decodeStringFromUtf7ImapToUtf8($str)
+    {
+        if (!\is_string($str)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($str).' given!');
+        }
+
+        $out = mb_convert_encoding($str, 'UTF-8', 'UTF7-IMAP');
+
+        if (!\is_string($out)) {
+            throw new UnexpectedValueException('mb_convert_encoding($str, \'UTF-8\', \'UTF7-IMAP\') could not convert $str');
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param false|resource $maybe
+     * @param string         $method
+     * @param int            $argument
+     *
+     * @throws InvalidArgumentException if $maybe is not a valid resource
+     *
+     * @return resource
+     */
+    private static function EnsureResource($maybe, $method, $argument)
+    {
+        if (!\is_string($method)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($method).' given!');
+        }
+        if (!\is_int($argument)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be an integer, '.\gettype($argument).' given!');
+        }
+
+        if (!$maybe || !\is_resource($maybe)) {
+            throw new InvalidArgumentException('Argument '.(string) $argument.' passed to '.$method.' must be a valid resource!');
+        }
+
+        /** @var resource */
+        return $maybe;
+    }
+
+    /**
+     * @param string $method
+     *
+     * @return UnexpectedValueException
+     */
+    private static function HandleErrors(array $errors, $method)
+    {
+        if (!\is_string($method)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($method).' given!');
+        }
+
+        if ($errors) {
+            return new UnexpectedValueException('IMAP method '.$method.'() failed with error: '.implode('. ', $errors));
+        }
+
+        return new UnexpectedValueException('IMAP method '.$method.'() failed!');
+    }
+
+    /**
+     * @param scalar $msg_number
+     * @param string $method
+     * @param int    $argument
+     * @param bool   $allow_sequence
+     *
+     * @return string
+     */
+    private static function EnsureRange(
+        $msg_number,
+        $method,
+        $argument,
+        $allow_sequence = false
+    ) {
+        if (!\is_int($msg_number) && !\is_string($msg_number)) {
+            throw new InvalidArgumentException('Argument 1 passed to '.__METHOD__.'() must be an integer or a string!');
+        }
+        if (!\is_string($method)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be a string, '.\gettype($method).' given!');
+        }
+        if (!\is_int($argument)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.' must be an integer, '.\gettype($argument).' given!');
+        }
+        if (!\is_bool($allow_sequence)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be a boolean, '.\gettype($allow_sequence).' given!');
+        }
+
+        if (\is_int($msg_number)) {
+            return sprintf('%1$s:%1$s', $msg_number);
+        } elseif (
+            $allow_sequence &&
+            1 !== preg_match('/^\d(?:(?:,\d+)+|:\d+)$/', $msg_number)
+        ) {
+            throw new InvalidArgumentException('Argument '.(string) $argument.' passed to '.$method.'() did not appear to be a valid message id range or sequence!');
+        } elseif (1 !== preg_match('/^\d+:\d+$/', $msg_number)) {
+            throw new InvalidArgumentException('Argument '.(string) $argument.' passed to '.$method.'() did not appear to be a valid message id range!');
+        }
+
+        return $msg_number;
+    }
+}

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -965,7 +965,7 @@ final class Imap
         }
 
         if (!$result) {
-            throw new UnexpectedValueException('Could not reopen mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_reopen'));
+            throw new UnexpectedValueException('Could not search mailbox!', 0, self::HandleErrors(imap_errors(), 'imap_search'));
         }
 
         /** @psalm-var list<int> */

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -479,6 +479,80 @@ final class Imap
     }
 
     /**
+     * @param resource|false $imap_stream
+     * @param string         $ref
+     * @param string         $pattern
+     *
+     * @return object[]
+     *
+     * @psalm-return list<object>
+     */
+    public static function getmailboxes(
+        $imap_stream,
+        $ref,
+        $pattern
+    ) {
+        if (!\is_string($ref)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($ref).' given!');
+        }
+        if (!\is_string($pattern)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be a string, '.\gettype($pattern).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_getmailboxes(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            $ref,
+            $pattern
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Call to imap_getmailboxes() with supplied arguments returned false, not array!', 0, self::HandleErrors(imap_errors(), 'imap_headers'));
+        }
+
+        /** @psalm-var list<object> */
+        return $result;
+    }
+
+    /**
+     * @param resource|false $imap_stream
+     * @param string         $ref
+     * @param string         $pattern
+     *
+     * @return object[]
+     *
+     * @psalm-return list<object>
+     */
+    public static function getsubscribed(
+        $imap_stream,
+        $ref,
+        $pattern
+    ) {
+        if (!\is_string($ref)) {
+            throw new InvalidArgumentException('Argument 2 passed to '.__METHOD__.'() must be a string, '.\gettype($ref).' given!');
+        }
+        if (!\is_string($pattern)) {
+            throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be a string, '.\gettype($pattern).' given!');
+        }
+
+        imap_errors(); // flush errors
+
+        $result = imap_getsubscribed(
+            self::EnsureResource($imap_stream, __METHOD__, 1),
+            $ref,
+            $pattern
+        );
+
+        if (false === $result) {
+            throw new UnexpectedValueException('Call to imap_getsubscribed() with supplied arguments returned false, not array!', 0, self::HandleErrors(imap_errors(), 'imap_headers'));
+        }
+
+        /** @psalm-var list<object> */
+        return $result;
+    }
+
+    /**
      * @param false|resource $imap_stream
      *
      * @return array

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -135,9 +135,8 @@ class IncomingMailAttachment
             return false;
         }
 
-        if (false === file_put_contents($this->filePath, $this->dataInfo->fetch())) {
-            unset($this->filePath);
-            unset($this->file_path);
+        if (false === file_put_contents($this->__get('filePath'), $this->dataInfo->fetch())) {
+            unset($this->filePath, $this->file_path);
 
             return false;
         }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -2,6 +2,7 @@
 
 namespace PhpImap;
 
+use function count;
 use DateTime;
 use Exception;
 use function iconv;
@@ -9,6 +10,7 @@ use InvalidArgumentException;
 use function mb_list_encodings;
 use PhpImap\Exceptions\ConnectionException;
 use PhpImap\Exceptions\InvalidParameterException;
+use Throwable;
 use UnexpectedValueException;
 
 /**
@@ -60,7 +62,7 @@ class Mailbox
     /** @var int */
     protected $imapRetriesNum = 0;
 
-    /** @var array */
+    /** @psalm-var array{DISABLE_AUTHENTICATOR?:string} */
     protected $imapParams = [];
 
     /** @var string */
@@ -244,7 +246,7 @@ class Mailbox
      *
      * @param int $imapSearchOption IMAP search option (eg. 'SE_UID')
      *
-     * @psalm-param 1|2 $imapSearchOptions
+     * @psalm-param 1|2 $imapSearchOption
      *
      * @return void
      *
@@ -330,23 +332,23 @@ class Mailbox
     /**
      * Set custom connection arguments of imap_open method. See http://php.net/imap_open.
      *
-     * @param int $options
-     * @param int $retriesNum
+     * @param int      $options
+     * @param int      $retriesNum
+     * @param string[] $params
      *
-     * @psalm-param mixed $params
+     * @psalm-param array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty>|null $params
      *
      * @return void
      *
      * @throws InvalidParameterException
      *
      * @todo drop support for php 5.6, set $options and $retriesNum to int
-     * @todo drop support for php 5.6, remove @psalm-param entry
      */
     public function setConnectionArgs($options = 0, $retriesNum = 0, array $params = null)
     {
-        if (0 != $options) {
+        if (0 !== $options) {
             $supported_options = [OP_READONLY, OP_ANONYMOUS, OP_HALFOPEN, CL_EXPUNGE, OP_DEBUG, OP_SHORTCACHE, OP_SILENT, OP_PROTOTYPE, OP_SECURE];
-            if (!\in_array($options, $supported_options)) {
+            if (!\in_array($options, $supported_options, true)) {
                 throw new InvalidParameterException('Please check your option for setConnectionArgs()! Unsupported option "'.$options.'". Available options: https://www.php.net/manual/de/function.imap-open.php');
             }
             $this->imapOptions = $options;
@@ -516,7 +518,7 @@ class Mailbox
             $this->imapPath = $this->getCombinedPath($imapPath, true);
         }
 
-        $this->imap('reopen', $this->imapPath);
+        Imap::reopen($this->getImapStream(), $this->imapPath);
     }
 
     /**
@@ -527,7 +529,7 @@ class Mailbox
     public function disconnect()
     {
         if ($this->hasImapStream()) {
-            $this->imap('close', [$this->getImapStream(false), $this->expungeOnDisconnect ? CL_EXPUNGE : 0], false, null);
+            Imap::close($this->getImapStream(false), $this->expungeOnDisconnect ? CL_EXPUNGE : 0);
         }
     }
 
@@ -553,14 +555,13 @@ class Mailbox
      *  Nmsgs - number of mails in the mailbox
      *  Recent - number of recent mails in the mailbox
      *
-     * @return object|false
+     * @see	imap_check
      *
-     * @see    imap_check
+     * @return object
      */
     public function checkMailbox()
     {
-        /** @var object|false */
-        return $this->imap('check');
+        return Imap::check($this->getImapStream());
     }
 
     /**
@@ -574,7 +575,7 @@ class Mailbox
      */
     public function createMailbox($name)
     {
-        $this->imap('createmailbox', $this->getCombinedPath($name));
+        Imap::createmailbox($this->getImapStream(), $this->getCombinedPath($name));
     }
 
     /**
@@ -588,8 +589,7 @@ class Mailbox
      */
     public function deleteMailbox($name)
     {
-        /** @var bool */
-        return $this->imap('deletemailbox', $this->getCombinedPath($name));
+        return Imap::deletemailbox($this->getImapStream(), $this->getCombinedPath($name));
     }
 
     /**
@@ -602,7 +602,7 @@ class Mailbox
      */
     public function renameMailbox($oldName, $newName)
     {
-        $this->imap('renamemailbox', [$this->getCombinedPath($oldName), $this->getCombinedPath($newName)]);
+        Imap::renamemailbox($this->getImapStream(), $this->getCombinedPath($oldName), $this->getCombinedPath($newName));
     }
 
     /**
@@ -615,8 +615,7 @@ class Mailbox
      */
     public function statusMailbox()
     {
-        /** @var object */
-        return $this->imap('status', [$this->imapPath, SA_ALL]);
+        return Imap::status($this->getImapStream(), $this->imapPath, SA_ALL);
     }
 
     /**
@@ -631,10 +630,7 @@ class Mailbox
      */
     public function getListingFolders($pattern = '*')
     {
-        /** @var string[] */
-        $folders = $this->imap('list', [$this->imapPath, $pattern]) ?: [];
-
-        return array_map([$this, 'decodeStringFromUtf7ImapToUtf8'], $folders);
+        return Imap::list($this->getImapStream(), $this->imapPath, $pattern);
     }
 
     /**
@@ -652,21 +648,25 @@ class Mailbox
     {
         if ($disableServerEncoding) {
             /** @psalm-var list<int> */
-            return $this->imap('search', [$criteria, $this->imapSearchOption]) ?: [];
+            return Imap::search($this->getImapStream(), $criteria, $this->imapSearchOption);
         }
 
         /** @psalm-var list<int> */
-        return $this->imap('search', [$criteria, $this->imapSearchOption, $this->getServerEncoding()]) ?: [];
+        return Imap::search($this->getImapStream(), $criteria, $this->imapSearchOption, $this->getServerEncoding());
     }
 
     /**
      * Search the mailbox for emails from multiple, specific senders.
      *
+     * @param string $criteria
+     * @param string $sender
+     * @param string ...$senders
+     *
      * @see Mailbox::searchMailboxFromWithOrWithoutDisablingServerEncoding()
      *
      * @return list<int>
      */
-    public function searchMailboxFrom(string $criteria, string $sender, string ...$senders)
+    public function searchMailboxFrom($criteria, $sender, ...$senders)
     {
         return $this->searchMailboxFromWithOrWithoutDisablingServerEncoding($criteria, false, $sender, ...$senders);
     }
@@ -674,11 +674,15 @@ class Mailbox
     /**
      * Search the mailbox for emails from multiple, specific senders whilst not using server encoding.
      *
+     * @param string $criteria
+     * @param string $sender
+     * @param string ...$senders
+     *
      * @see Mailbox::searchMailboxFromWithOrWithoutDisablingServerEncoding()
      *
      * @return list<int>
      */
-    public function searchMailboxFromDisableServerEncoding(string $criteria, string $sender, string ...$senders)
+    public function searchMailboxFromDisableServerEncoding($criteria, $sender, ...$senders)
     {
         return $this->searchMailboxFromWithOrWithoutDisablingServerEncoding($criteria, true, $sender, ...$senders);
     }
@@ -695,7 +699,7 @@ class Mailbox
      */
     public function saveMail($mailId, $filename = 'email.eml')
     {
-        $this->imap('savebody', [$filename, $mailId, '', (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
+        Imap::savebody($this->getImapStream(), $filename, $mailId, '', (SE_UID === $this->imapSearchOption) ? FT_UID : 0);
     }
 
     /**
@@ -709,7 +713,7 @@ class Mailbox
      */
     public function deleteMail($mailId)
     {
-        $this->imap('delete', [$mailId.':'.$mailId, (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
+        Imap::delete($this->getImapStream(), $mailId, (SE_UID === $this->imapSearchOption) ? FT_UID : 0);
     }
 
     /**
@@ -724,7 +728,8 @@ class Mailbox
      */
     public function moveMail($mailId, $mailBox)
     {
-        $this->imap('mail_move', [(string) $mailId, $mailBox, CP_UID]) && $this->expungeDeletedMails();
+        Imap::mail_move($this->getImapStream(), $mailId, $mailBox, CP_UID);
+        $this->expungeDeletedMails();
     }
 
     /**
@@ -739,7 +744,8 @@ class Mailbox
      */
     public function copyMail($mailId, $mailBox)
     {
-        $this->imap('mail_copy', [(string) $mailId, $mailBox, CP_UID]) && $this->expungeDeletedMails();
+        Imap::mail_copy($this->getImapStream(), $mailId, $mailBox, CP_UID);
+        $this->expungeDeletedMails();
     }
 
     /**
@@ -751,7 +757,7 @@ class Mailbox
      */
     public function expungeDeletedMails()
     {
-        $this->imap('expunge');
+        Imap::expunge($this->getImapStream());
     }
 
     /**
@@ -807,6 +813,10 @@ class Mailbox
     /**
      * Remove the flag \Seen from some mails.
      *
+     * @param int[] $mailId
+     *
+     * @psalm-param list<int> $mailId
+     *
      * @return void
      */
     public function markMailsAsUnread(array $mailId)
@@ -816,6 +826,8 @@ class Mailbox
 
     /**
      * Add the flag \Flagged to some mails.
+     *
+     * @param int[] $mailId
      *
      * @psalm-param list<int> $mailId
      *
@@ -832,13 +844,11 @@ class Mailbox
      * @param array  $mailsIds Array of mail IDs
      * @param string $flag     Which you can set are \Seen, \Answered, \Flagged, \Deleted, and \Draft as defined by RFC2060
      *
-     * @psalm-param list<int> $mailsIds
-     *
      * @return void
      */
     public function setFlag(array $mailsIds, $flag)
     {
-        $this->imap('setflag_full', [implode(',', $mailsIds), $flag, ST_UID]);
+        Imap::setflag_full($this->getImapStream(), implode(',', $mailsIds), $flag, ST_UID);
     }
 
     /**
@@ -851,7 +861,7 @@ class Mailbox
      */
     public function clearFlag(array $mailsIds, $flag)
     {
-        $this->imap('clearflag_full', [implode(',', $mailsIds), $flag, ST_UID]);
+        Imap::clearflag_full($this->getImapStream(), implode(',', $mailsIds), $flag, ST_UID);
     }
 
     /**
@@ -876,10 +886,6 @@ class Mailbox
      *  seen - this mail is flagged as already read
      *  draft - this mail is flagged as being a draft
      *
-     * @param int[] $mailsIds
-     *
-     * @psalm-param list<int> $mailsIds
-     *
      * @return array $mailsIds Array of mail IDs
      *
      * @psalm-return list<object>
@@ -888,9 +894,12 @@ class Mailbox
      */
     public function getMailsInfo(array $mailsIds)
     {
-        /** @var list<object>|false */
-        $mails = $this->imap('fetch_overview', [implode(',', $mailsIds), (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
-        if (\is_array($mails) && \count($mails)) {
+        $mails = Imap::fetch_overview(
+            $this->getImapStream(),
+            implode(',', $mailsIds),
+            (SE_UID === $this->imapSearchOption) ? FT_UID : 0
+        );
+        if (\count($mails)) {
             foreach ($mails as $index => &$mail) {
                 if (isset($mail->subject) && !\is_string($mail->subject)) {
                     throw new UnexpectedValueException('subject property at index '.(string) $index.' of argument 1 passed to '.__METHOD__.'() was not a string!');
@@ -935,8 +944,7 @@ class Mailbox
      */
     public function getMailboxHeaders()
     {
-        /** @var array */
-        return $this->imap('headers');
+        return Imap::headers($this->getImapStream());
     }
 
     /**
@@ -954,12 +962,11 @@ class Mailbox
      *
      * @return object Object with info
      *
-     * @see    mailboxmsginfo
+     * @see	mailboxmsginfo
      */
     public function getMailboxInfo()
     {
-        /** @var object */
-        return $this->imap('mailboxmsginfo');
+        return Imap::mailboxmsginfo($this->getImapStream());
     }
 
     /**
@@ -978,12 +985,20 @@ class Mailbox
      * @param bool   $reverse        Sort reverse or not
      * @param string $searchCriteria See http://php.net/imap_search for a complete list of available criteria
      *
+     * @psalm-param value-of<Imap::SORT_CRITERIA> $criteria
+     * @psalm-param 1|5|0|2|6|3|4 $criteria
+     *
      * @return array Mails ids
      */
     public function sortMails($criteria = SORTARRIVAL, $reverse = true, $searchCriteria = 'ALL')
     {
-        /** @var array */
-        return $this->imap('sort', [$criteria, $reverse, $this->imapSearchOption, $searchCriteria]);
+        return Imap::sort(
+            $this->getImapStream(),
+            $criteria,
+            $reverse,
+            $this->imapSearchOption,
+            $searchCriteria
+        );
     }
 
     /**
@@ -995,8 +1010,7 @@ class Mailbox
      */
     public function countMails()
     {
-        /** @var int */
-        return $this->imap('num_msg');
+        return Imap::num_msg($this->getImapStream());
     }
 
     /**
@@ -1044,8 +1058,7 @@ class Mailbox
             $options |= FT_PEEK;
         }
 
-        /** @var string */
-        return $this->imap('fetchbody', [$msgId, '', $options]);
+        return Imap::fetchbody($this->getImapStream(), $msgId, '', $options);
     }
 
     /**
@@ -1061,12 +1074,11 @@ class Mailbox
      */
     public function getMailHeader($mailId)
     {
-        /** @var string|false */
-        $headersRaw = $this->imap('fetchheader', [$mailId, (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
-
-        if (false === $headersRaw) {
-            throw new Exception('Empty mail header - fetchheader failed. Invalid mail ID?');
-        }
+        $headersRaw = Imap::fetchheader(
+            $this->getImapStream(),
+            $mailId,
+            (SE_UID === $this->imapSearchOption) ? FT_UID : 0
+        );
 
         /** @var object{
          * date?:scalar,
@@ -1245,8 +1257,11 @@ class Mailbox
         $mail = new IncomingMail();
         $mail->setHeader($this->getMailHeader($mailId));
 
-        /** @psalm-var PARTSTRUCTURE */
-        $mailStructure = $this->imap('fetchstructure', [$mailId, (SE_UID == $this->imapSearchOption) ? FT_UID : 0]);
+        $mailStructure = Imap::fetchstructure(
+            $this->getImapStream(),
+            $mailId,
+            (SE_UID === $this->imapSearchOption) ? FT_UID : 0
+        );
 
         if (empty($mailStructure->parts)) {
             $this->initMailPart($mail, $mailStructure, 0, $markAsSeen);
@@ -1512,7 +1527,10 @@ class Mailbox
      */
     public function subscribeMailbox($mailbox)
     {
-        $this->imap('subscribe', $this->getCombinedPath($mailbox));
+        Imap::subscribe(
+            $this->getImapStream(),
+            $this->getCombinedPath($mailbox)
+        );
     }
 
     /**
@@ -1526,74 +1544,10 @@ class Mailbox
      */
     public function unsubscribeMailbox($mailbox)
     {
-        $this->imap('unsubscribe', $this->getCombinedPath($mailbox));
-    }
-
-    /**
-     * Call IMAP extension function call wrapped with utf7 args conversion & errors handling.
-     *
-     * @param string       $methodShortName             Name of PHP imap_ method, but without the 'imap_' prefix. (eg. imap_fetch_overview => fetch_overview)
-     * @param array|string $args                        All arguments of the original method, except the 'resource $imap_stream' (eg. imap_fetch_overview => string $sequence [, int $options = 0 ])
-     * @param bool         $prependConnectionAsFirstArg Add 'resource $imap_stream' as first argument, if set to true
-     * @param string|null  $throwExceptionClass         Name of exception class, which will be thrown in case of errors
-     *
-     * @psalm-param list<scalar|array|object|resource|null>|string $args
-     * @psalm-param class-string<Exception>|null $throwExceptionClass
-     *
-     * @return scalar|array|object|resource|null
-     *
-     * @throws Exception
-     */
-    public function imap($methodShortName, $args = [], $prependConnectionAsFirstArg = true, $throwExceptionClass = Exception::class)
-    {
-        $method_name = 'imap_'.$methodShortName;
-        if (!\function_exists($method_name)) {
-            throw new InvalidArgumentException('Argument 1 passed to '.__METHOD__.'() did not correspond to a known imap_* function');
-        }
-        if (!\is_array($args)) {
-            $args = [$args];
-        }
-        // https://github.com/barbushin/php-imap/issues/242
-        if (\in_array($methodShortName, ['open'])) {
-            // Mailbox names that contain international characters besides those in the printable ASCII space have to be encoded with imap_utf7_encode().
-            // https://www.php.net/manual/en/function.imap-open.php
-            if (\is_string($args[0])) {
-                if (preg_match("/^\{.*\}(.*)$/", $args[0], $matches)) {
-                    $mailbox_name = $matches[1];
-
-                    if (!mb_detect_encoding($mailbox_name, 'ASCII', true)) {
-                        $args[0] = $this->encodeStringToUtf7Imap($mailbox_name);
-                    }
-                }
-            }
-        } else {
-            foreach ($args as &$arg) {
-                if (\is_string($arg)) {
-                    $arg = $this->encodeStringToUtf7Imap($arg);
-                }
-            }
-        }
-        if ($prependConnectionAsFirstArg) {
-            array_unshift($args, $this->getImapStream());
-        }
-
-        imap_errors(); // flush errors
-
-        /** @var scalar|array|object|resource|null */
-        $result = @\call_user_func_array($method_name, $args);
-
-        if (!$result) {
-            $errors = imap_errors();
-            if ($errors) {
-                if ($throwExceptionClass) {
-                    throw new $throwExceptionClass("IMAP method $method_name() failed with error: ".implode('. ', $errors));
-                } else {
-                    return false;
-                }
-            }
-        }
-
-        return $result;
+        Imap::unsubscribe(
+            $this->getImapStream(),
+            $this->getCombinedPath($mailbox)
+        );
     }
 
     /**
@@ -1624,13 +1578,9 @@ class Mailbox
         }
 
         try {
-            $mailbox_info = $this->imap('check');
-        } catch (Exception $ex) {
+            $this->checkMailbox();
+        } catch (Throwable $ex) {
             throw new Exception('OAuth authentication failed! IMAP Error: '.$ex->getMessage());
-        }
-
-        if (false === $mailbox_info) {
-            throw new Exception('OAuth authentication failed! imap_check() could not gather any mailbox information.');
         }
     }
 
@@ -1650,19 +1600,40 @@ class Mailbox
     }
 
     /**
+     * Retrieve the quota settings per user.
+     *
+     * @param string $quota_root Should normally be in the form of which mailbox (i.e. INBOX)
+     *
+     * @see	imap_get_quotaroot()
+     *
+     * @return array[]
+     */
+    protected function getQuota($quota_root = 'INBOX')
+    {
+        return Imap::get_quotaroot($this->getImapStream(), $quota_root);
+    }
+
+    /**
      * Open an IMAP stream to a mailbox.
      *
-     * @return resource IMAP stream on success
-     *
      * @throws Exception if an error occured
+     *
+     * @return resource IMAP stream on success
      */
     protected function initImapStream()
     {
         foreach ($this->timeouts as $type => $timeout) {
-            $this->imap('timeout', [$type, $timeout], false);
+            Imap::timeout($type, $timeout);
         }
 
-        $imapStream = @imap_open($this->imapPath, $this->imapLogin, $this->imapPassword, $this->imapOptions, $this->imapRetriesNum, $this->imapParams);
+        $imapStream = Imap::open(
+            $this->imapPath,
+            $this->imapLogin,
+            $this->imapPassword,
+            $this->imapOptions,
+            $this->imapRetriesNum,
+            $this->imapParams
+        );
 
         if (!$imapStream) {
             $lastError = imap_last_error();
@@ -1674,35 +1645,19 @@ class Mailbox
             if (!empty(trim($lastError))) {
                 // imap error = report imap error
                 throw new Exception('IMAP error: '.$lastError);
-            } else {
-                // no imap error = connectivity issue
-                throw new Exception('Connection error: Unable to connect to '.$this->imapPath);
             }
+            // no imap error = connectivity issue
+            throw new Exception('Connection error: Unable to connect to '.$this->imapPath);
         }
 
         return $imapStream;
     }
 
     /**
-     * Retrieve the quota settings per user.
-     *
-     * @param string $quota_root Should normally be in the form of which mailbox (i.e. INBOX)
-     *
-     * @return array
-     *
-     * @see    imap_get_quotaroot()
-     */
-    protected function getQuota($quota_root = 'INBOX')
-    {
-        /** @var array */
-        return $this->imap('get_quotaroot', $quota_root);
-    }
-
-    /**
-     * @param object     $partStructure
-     * @param string|int $partNum
-     * @param bool       $markAsSeen
-     * @param bool       $emlParse
+     * @param object   $partStructure
+     * @param string|0 $partNum
+     * @param bool     $markAsSeen
+     * @param bool     $emlParse
      *
      * @psalm-param PARTSTRUCTURE $partStructure
      *
@@ -1716,7 +1671,7 @@ class Mailbox
             throw new InvalidArgumentException('Argument 1 passeed to '.__METHOD__.'() did not have the id property set!');
         }
 
-        $options = (SE_UID == $this->imapSearchOption) ? FT_UID : 0;
+        $options = (SE_UID === $this->imapSearchOption) ? FT_UID : 0;
 
         if (!$markAsSeen) {
             $options |= FT_PEEK;
@@ -1757,7 +1712,7 @@ class Mailbox
         }
 
         // check if the part is a subpart of another attachment part (RFC822)
-        if ('RFC822' == $partStructure->subtype && isset($partStructure->disposition) && 'attachment' == $partStructure->disposition) {
+        if ('RFC822' === $partStructure->subtype && isset($partStructure->disposition) && 'attachment' === $partStructure->disposition) {
             // Although we are downloading each part separately, we are going to download the EML to a single file
             //incase someone wants to process or parse in another process
             $attachment = self::downloadAttachment($dataInfo, $params, $partStructure, $mail->id, false);
@@ -1772,7 +1727,7 @@ class Mailbox
         // Do NOT parse attachments, when getAttachmentsIgnore() is true
         if ($this->getAttachmentsIgnore()
             && (TYPEMULTIPART !== $partStructure->type
-            && (TYPETEXT !== $partStructure->type || !\in_array(strtolower($partStructure->subtype), ['plain', 'html'])))
+            && (TYPETEXT !== $partStructure->type || !\in_array(mb_strtolower($partStructure->subtype), ['plain', 'html'], true)))
         ) {
             return;
         }
@@ -1781,7 +1736,7 @@ class Mailbox
             $attachment = self::downloadAttachment($dataInfo, $params, $partStructure, $mail->id, $emlParse);
             $mail->addAttachment($attachment);
         } else {
-            if (isset($params['charset']) and !empty(trim($params['charset']))) {
+            if (isset($params['charset']) && !empty(trim($params['charset']))) {
                 $dataInfo->charset = $params['charset'];
             }
         }
@@ -1790,12 +1745,12 @@ class Mailbox
             foreach ($partStructure->parts as $subPartNum => $subPartStructure) {
                 $not_attachment = (!isset($partStructure->disposition) || 'attachment' !== $partStructure->disposition);
 
-                if (TYPEMESSAGE === $partStructure->type && 'RFC822' == $partStructure->subtype && $not_attachment) {
+                if (TYPEMESSAGE === $partStructure->type && 'RFC822' === $partStructure->subtype && $not_attachment) {
                     $this->initMailPart($mail, $subPartStructure, $partNum, $markAsSeen);
-                } elseif (TYPEMULTIPART === $partStructure->type && 'ALTERNATIVE' == $partStructure->subtype && $not_attachment) {
+                } elseif (TYPEMULTIPART === $partStructure->type && 'ALTERNATIVE' === $partStructure->subtype && $not_attachment) {
                     // https://github.com/barbushin/php-imap/issues/198
                     $this->initMailPart($mail, $subPartStructure, $partNum, $markAsSeen);
-                } elseif ('RFC822' == $partStructure->subtype && isset($partStructure->disposition) && 'attachment' == $partStructure->disposition) {
+                } elseif ('RFC822' === $partStructure->subtype && isset($partStructure->disposition) && 'attachment' === $partStructure->disposition) {
                     //If it comes from am EML attachment, download each part separately as a file
                     $this->initMailPart($mail, $subPartStructure, $partNum.'.'.($subPartNum + 1), $markAsSeen, true);
                 } else {
@@ -1804,13 +1759,13 @@ class Mailbox
             }
         } else {
             if (TYPETEXT === $partStructure->type) {
-                if ('plain' == strtolower($partStructure->subtype)) {
+                if ('plain' === mb_strtolower($partStructure->subtype)) {
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_PLAIN);
                 } elseif (!$partStructure->ifdisposition) {
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_HTML);
                 } elseif (!\is_string($partStructure->disposition)) {
                     throw new InvalidArgumentException('disposition property of object passed as argument 2 to '.__METHOD__.'() was present but not a string!');
-                } elseif ('attachment' != strtolower($partStructure->disposition)) {
+                } elseif ('attachment' !== mb_strtolower($partStructure->disposition)) {
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_HTML);
                 }
             } elseif (TYPEMESSAGE === $partStructure->type) {
@@ -1995,11 +1950,16 @@ class Mailbox
     /**
      * Search the mailbox for emails from multiple, specific senders.
      *
+     * @param string $criteria
+     * @param bool   $disableServerEncoding
+     * @param string $sender
+     * @param string ...$senders
+     *
      * This function wraps Mailbox::searchMailbox() to overcome a shortcoming in ext-imap
      *
      * @return list<int>
      */
-    protected function searchMailboxFromWithOrWithoutDisablingServerEncoding(string $criteria, bool $disableServerEncoding, string $sender, string ...$senders)
+    protected function searchMailboxFromWithOrWithoutDisablingServerEncoding($criteria, $disableServerEncoding, $sender, ...$senders)
     {
         array_unshift($senders, $sender);
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1639,21 +1639,6 @@ class Mailbox
             $this->imapParams
         );
 
-        if (!$imapStream) {
-            $lastError = imap_last_error();
-
-            // this function is called multiple times and imap keeps errors around.
-            // Let's clear them out to avoid it tripping up future calls.
-            @imap_errors();
-
-            if (!empty(trim($lastError))) {
-                // imap error = report imap error
-                throw new Exception('IMAP error: '.$lastError);
-            }
-            // no imap error = connectivity issue
-            throw new Exception('Connection error: Unable to connect to '.$this->imapPath);
-        }
-
         return $imapStream;
     }
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1491,12 +1491,8 @@ class Mailbox
      */
     public function getMailboxes($search = '*')
     {
-        /** @psalm-var (scalar|array|object|resource|null)[]|false */
-        $mailboxes = imap_getmailboxes($this->getImapStream(), $this->imapPath, $search);
-
-        if (!\is_array($mailboxes)) {
-            throw new UnexpectedValueException('Call to imap_getmailboxes() with supplied arguments returned false, not array!');
-        }
+        /** @psalm-var array<int, scalar|array|object{name?:string}|resource|null> */
+        $mailboxes = Imap::getmailboxes($this->getImapStream(), $this->imapPath, $search);
 
         return $this->possiblyGetMailboxes($mailboxes);
     }
@@ -1510,12 +1506,8 @@ class Mailbox
      */
     public function getSubscribedMailboxes($search = '*')
     {
-        /** @psalm-var (scalar|array|object|resource|null)[]|false */
-        $mailboxes = (array) imap_getsubscribed($this->getImapStream(), $this->imapPath, $search);
-
-        if (!\is_array($mailboxes)) {
-            throw new UnexpectedValueException('Call to imap_getmailboxes() with supplied arguments returned false, not array!');
-        }
+        /** @psalm-var array<int, scalar|array|object{name?:string}|resource|null> */
+        $mailboxes = Imap::getsubscribed($this->getImapStream(), $this->imapPath, $search);
 
         return $this->possiblyGetMailboxes($mailboxes);
     }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -664,7 +664,9 @@ class Mailbox
      *
      * @see Mailbox::searchMailboxFromWithOrWithoutDisablingServerEncoding()
      *
-     * @return list<int>
+     * @return int[]
+     *
+     * @psalm-return list<int>
      */
     public function searchMailboxFrom($criteria, $sender, ...$senders)
     {
@@ -680,7 +682,9 @@ class Mailbox
      *
      * @see Mailbox::searchMailboxFromWithOrWithoutDisablingServerEncoding()
      *
-     * @return list<int>
+     * @return int[]
+     *
+     * @psalm-return list<int>
      */
     public function searchMailboxFromDisableServerEncoding($criteria, $sender, ...$senders)
     {
@@ -1957,13 +1961,15 @@ class Mailbox
      *
      * This function wraps Mailbox::searchMailbox() to overcome a shortcoming in ext-imap
      *
-     * @return list<int>
+     * @return int[]
+     *
+     * @psalm-return list<int>
      */
     protected function searchMailboxFromWithOrWithoutDisablingServerEncoding($criteria, $disableServerEncoding, $sender, ...$senders)
     {
         array_unshift($senders, $sender);
 
-        /** @var list<string> */
+        /** @psalm-var list<string> */
         $senders = array_values(array_unique(array_map('mb_strtolower', $senders)));
 
         $out = [];
@@ -1972,7 +1978,7 @@ class Mailbox
             $out = array_merge($out, $this->searchMailbox($criteria.' FROM '.$sender, $disableServerEncoding));
         }
 
-        /** @var list<int> */
+        /** @psalm-var list<int> */
         return array_values(array_unique($out, SORT_NUMERIC));
     }
 }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1945,7 +1945,7 @@ class Mailbox
      */
     protected function pingOrDisconnect()
     {
-        if ($this->imapStream && (!\is_resource($this->imapStream) || !imap_ping($this->imapStream))) {
+        if ($this->imapStream && !Imap::ping($this->imapStream)) {
             $this->disconnect();
             $this->imapStream = null;
         }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1479,7 +1479,7 @@ class Mailbox
     {
         $option = (SE_UID == $this->imapSearchOption) ? FT_UID : 0;
 
-        return imap_fetchheader($this->getImapStream(), $mailId, $option && FT_PREFETCHTEXT).imap_body($this->getImapStream(), $mailId, $option);
+        return imap_fetchheader($this->getImapStream(), $mailId, $option | FT_PREFETCHTEXT).Imap::body($this->getImapStream(), $mailId, $option);
     }
 
     /**

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -630,7 +630,7 @@ class Mailbox
      */
     public function getListingFolders($pattern = '*')
     {
-        return Imap::list($this->getImapStream(), $this->imapPath, $pattern);
+        return Imap::listOfMailboxes($this->getImapStream(), $this->imapPath, $pattern);
     }
 
     /**

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -72,14 +72,12 @@ class LiveMailboxTest extends TestCase
             $limit = min(count($mailboxes), self::RANDOM_MAILBOX_SAMPLE_SIZE);
 
             for ($i = 0; $i < $limit; ++$i) {
-                $this->assertTrue(is_array($mailboxes[$i]));
-                $this->assertTrue(isset($mailboxes[$i]['shortpath']));
-                $this->assertTrue(is_string($mailboxes[$i]['shortpath']));
+                static::assertTrue(is_array($mailboxes[$i]));
+                static::assertTrue(isset($mailboxes[$i]['shortpath']));
+                static::assertTrue(is_string($mailboxes[$i]['shortpath']));
                 $mailbox->switchMailbox($mailboxes[$i]['shortpath']);
 
                 $check = $mailbox->checkMailbox();
-
-                $this->assertTrue(is_object($check));
 
                 foreach ([
                     'Date',

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -639,11 +639,11 @@ final class MailboxTest extends TestCase
     /**
      * Provides test data for testing connection args.
      *
-     * @psalm-return list<array{0:'assertNull'|'expectException', 1:int, 2:int, 3:array}>
+     * @psalm-return list<array{0:'assertNull'|'expectException', 1:int, 2:int, 3:array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty>}>
      */
     public function connectionArgsProvider()
     {
-        /** @psalm-var list<array{0:'assertNull'|'expectException', 1:int, 2:int, 3:array}> */
+        /** @psalm-var list<array{0:'assertNull'|'expectException', 1:int, 2:int, 3:array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty>}> */
         return [
             ['assertNull', OP_READONLY, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
             ['assertNull', OP_READONLY, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
@@ -678,6 +678,8 @@ final class MailboxTest extends TestCase
      * @param int        $option
      * @param int        $retriesNum
      * @param array|null $param
+     *
+     * @psalm-param array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty> $param
      *
      * @return void
      */

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -216,7 +216,7 @@ final class MailboxTest extends TestCase
         $this->assertEquals($this->mailbox->getImapSearchOption(), 2);
 
         $this->expectException(InvalidParameterException::class);
-        $this->mailbox->setImapSearchOption(ANYTHING);
+        $this->mailbox->setImapSearchOption(constant('ANYTHING'));
 
         $this->mailbox->setImapSearchOption(SE_UID);
         $this->assertEquals($this->mailbox->getImapSearchOption(), 1);


### PR DESCRIPTION
kept on stumbling into type errors re: #432, so I've backported a strongly-typed implementation from my fork that only supports php 7.4.

github had a little snafu- I was trying to leave this as a draft while I tinkered with the implementation further.