### PR TITLE
Modify/imap implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ vendor/
 composer.lock
 *.phar
 .php_cs.cache
+coverage/
 
 #################
 ## Eclipse

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ before_script:
 
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
-  - vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure
+  - vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure --exclude-group=live
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure --group=live; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit && ./vendor/bin/psalm --show-info=false --shepherd; fi
   - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
   - vendor/bin/phpunit --coverage-php=coverage/not-live.cov --stop-on-failure --exclude-group=live
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit phpunit/phpcov maglnet/composer-require-checker paragonie/hidden-string; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit symfony/console:^4 phpunit/phpcov maglnet/composer-require-checker paragonie/hidden-string; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-php=coverage/live.cov --stop-on-failure --group=live,compose; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/psalm --show-info=false --shepherd; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ before_script:
 
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
-  - vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure --exclude-group=live
+  - vendor/bin/phpunit --coverage-php=coverage/not-live.cov --stop-on-failure --exclude-group=live
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure --group=live,compose; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-php=coverage/live.cov --stop-on-failure --group=live,compose; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit && ./vendor/bin/psalm --show-info=false --shepherd; fi
   - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v
+  - vendor/bin/phpcov merge ./coverage/ --clover clover.xml
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
   - vendor/bin/phpunit --coverage-php=coverage/not-live.cov --stop-on-failure --exclude-group=live
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit symfony/console:^4 phpunit/phpcov maglnet/composer-require-checker paragonie/hidden-string; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit symfony/console:^4 phpunit/phpcov maglnet/composer-require-checker:^2.0 paragonie/hidden-string; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-php=coverage/live.cov --stop-on-failure --group=live,compose; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/psalm --show-info=false --shepherd; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-php=coverage/live.cov --stop-on-failure --group=live,compose; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit && ./vendor/bin/psalm --show-info=false --shepherd; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit phpunit/phpcov && ./vendor/bin/psalm --show-info=false --shepherd; fi
   - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v
   - vendor/bin/phpcov merge ./coverage/ --clover clover.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - vendor/bin/phpunit --coverage-php=coverage/not-live.cov --stop-on-failure --exclude-group=live
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-php=coverage/live.cov --stop-on-failure --group=live,compose; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit phpunit/phpcov && ./vendor/bin/psalm --show-info=false --shepherd; fi
   - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v
   - vendor/bin/phpcov merge ./coverage/ --clover clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
   - if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.6" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
-  - vendor/bin/phpunit --coverage-clover=clover.xml
+  - vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit && ./vendor/bin/psalm --show-info=false --shepherd; fi
   - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
   - vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure --exclude-group=live
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure --group=live; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure --group=live,compose; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require ext-fileinfo:* maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit && ./vendor/bin/psalm --show-info=false --shepherd; fi
   - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ before_script:
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
   - vendor/bin/phpunit --coverage-php=coverage/not-live.cov --stop-on-failure --exclude-group=live
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies paragonie/hidden-string; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit phpunit/phpcov maglnet/composer-require-checker paragonie/hidden-string; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-php=coverage/live.cov --stop-on-failure --group=live,compose; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require maglnet/composer-require-checker && ./vendor/bin/composer-require-checker check ./composer.json; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit phpunit/phpcov && ./vendor/bin/psalm --show-info=false --shepherd; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/composer-require-checker check ./composer.json; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/psalm --show-info=false --shepherd; fi
   - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v
   - vendor/bin/phpcov merge ./coverage/ --clover clover.xml
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "ext-fileinfo": "*",
         "friendsofphp/php-cs-fixer": "^2.16",
         "jakub-onderka/php-parallel-lint": "^1.0",
+        "paragonie/random_compat": "^1",
         "phpunit/phpunit": "^5.7"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "friendsofphp/php-cs-fixer": "^2.16",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "paragonie/random_compat": "^1",
+        "phpunit/phpcov": "^3",
         "phpunit/phpunit": "^5.7"
     },
     "suggest": {

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -102,6 +102,9 @@
       <code>\is_int($retriesNum)</code>
       <code>\in_array($key, $supported_params, true)</code>
     </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>random_bytes(16)</code>
+    </InvalidArgument>
     <PossiblyUnusedMethod occurrences="27">
       <code>setOAuthToken</code>
       <code>getOAuthToken</code>
@@ -143,7 +146,15 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/unit/LiveMailboxTest.php">
-    <PossiblyNullArgument occurrences="2">
+    <InvalidArgument occurrences="3">
+      <code>random_bytes(16)</code>
+      <code>random_bytes(16)</code>
+      <code>random_bytes(16)</code>
+    </InvalidArgument>
+    <PossiblyNullArgument occurrences="5">
+      <code>$envelope['subject']</code>
+      <code>$envelope['subject']</code>
+      <code>$envelope['subject']</code>
       <code>$envelope['subject']</code>
       <code>$envelope['subject']</code>
     </PossiblyNullArgument>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -143,7 +143,8 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/unit/LiveMailboxTest.php">
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="2">
+      <code>$envelope['subject']</code>
       <code>$envelope['subject']</code>
     </PossiblyNullArgument>
   </file>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -6,7 +6,13 @@
     </UnusedVariable>
   </file>
   <file src="src/PhpImap/Imap.php">
-    <DocblockTypeContradiction occurrences="67">
+    <DocblockTypeContradiction occurrences="73">
+      <code>\is_string($mailbox)</code>
+      <code>\is_string($message)</code>
+      <code>\is_string($options)</code>
+      <code>null !== $options &amp;&amp; !\is_string($options)</code>
+      <code>\is_string($internal_date)</code>
+      <code>null !== $internal_date &amp;&amp; !\is_string($internal_date)</code>
       <code>\is_int($msg_number)</code>
       <code>\is_int($options)</code>
       <code>\is_string($flag)</code>
@@ -135,6 +141,11 @@
       <code>\is_string($attachment-&gt;id)</code>
       <code>assertTrue</code>
     </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="tests/unit/LiveMailboxTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$envelope['subject']</code>
+    </PossiblyNullArgument>
   </file>
   <file src="tests/unit/MailboxTest.php">
     <DeprecatedMethod occurrences="8">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -100,7 +100,7 @@
       <code>\is_int($retriesNum)</code>
       <code>\in_array($key, $supported_params, true)</code>
     </DocblockTypeContradiction>
-    <PossiblyUnusedMethod occurrences="32">
+    <PossiblyUnusedMethod occurrences="31">
       <code>setOAuthToken</code>
       <code>getOAuthToken</code>
       <code>setConnectionRetry</code>
@@ -113,7 +113,6 @@
       <code>searchMailboxFrom</code>
       <code>searchMailboxFromDisableServerEncoding</code>
       <code>saveMail</code>
-      <code>deleteMail</code>
       <code>moveMail</code>
       <code>copyMail</code>
       <code>markMailAsUnread</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -80,10 +80,6 @@
       <code>$result</code>
       <code>array[]</code>
     </MixedReturnTypeCoercion>
-    <PossiblyNullArgument occurrences="2">
-      <code>null === $search_criteria ? null : self::encodeStringToUtf7Imap($search_criteria)</code>
-      <code>null === $charset ? null : self::encodeStringToUtf7Imap($charset)</code>
-    </PossiblyNullArgument>
   </file>
   <file src="src/PhpImap/IncomingMail.php">
     <PossiblyUnusedMethod occurrences="2">
@@ -100,7 +96,7 @@
       <code>\is_int($retriesNum)</code>
       <code>\in_array($key, $supported_params, true)</code>
     </DocblockTypeContradiction>
-    <PossiblyUnusedMethod occurrences="31">
+    <PossiblyUnusedMethod occurrences="27">
       <code>setOAuthToken</code>
       <code>getOAuthToken</code>
       <code>setConnectionRetry</code>
@@ -120,15 +116,11 @@
       <code>markMailsAsRead</code>
       <code>markMailsAsUnread</code>
       <code>markMailsAsImportant</code>
-      <code>getMailsInfo</code>
       <code>getMailboxHeaders</code>
       <code>getMailboxInfo</code>
-      <code>sortMails</code>
       <code>getQuotaLimit</code>
       <code>getQuotaUsage</code>
-      <code>getRawMail</code>
       <code>getImapPath</code>
-      <code>getMailMboxFormat</code>
       <code>getSubscribedMailboxes</code>
       <code>subscribeMailbox</code>
       <code>unsubscribeMailbox</code>

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -1146,14 +1146,34 @@ final class Imap
 
         imap_errors(); // flush errors
 
-        $result = imap_sort(
-            self::EnsureResource($imap_stream, __METHOD__, 1),
-            $criteria,
-            (int) $reverse,
-            $options,
-            null === $search_criteria ? null : self::encodeStringToUtf7Imap($search_criteria),
-            null === $charset ? null : self::encodeStringToUtf7Imap($charset)
-        );
+        $imap_stream = self::EnsureResource($imap_stream, __METHOD__, 1);
+        $reverse = (int) $reverse;
+
+        if (null !== $search_criteria && null !== $charset) {
+            $result = imap_sort(
+                $imap_stream,
+                $criteria,
+                $reverse,
+                $options,
+                self::encodeStringToUtf7Imap($search_criteria),
+                self::encodeStringToUtf7Imap($charset)
+            );
+        } elseif (null !== $search_criteria) {
+            $result = imap_sort(
+                $imap_stream,
+                $criteria,
+                $reverse,
+                $options,
+                self::encodeStringToUtf7Imap($search_criteria)
+            );
+        } else {
+            $result = imap_sort(
+                $imap_stream,
+                $criteria,
+                $reverse,
+                $options
+            );
+        }
 
         if (!$result) {
             throw new UnexpectedValueException('Could not sort messages!', 0, self::HandleErrors(imap_errors(), 'imap_sort'));

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -1427,7 +1427,7 @@ final class Imap
             return sprintf('%1$s:%1$s', $msg_number);
         } elseif (
             $allow_sequence &&
-            1 !== preg_match('/^\d(?:(?:,\d+)+|:\d+)$/', $msg_number)
+            1 !== preg_match('/^\d+(?:(?:,\d+)+|:\d+)$/', $msg_number)
         ) {
             throw new InvalidArgumentException('Argument '.(string) $argument.' passed to '.$method.'() did not appear to be a valid message id range or sequence!');
         } elseif (1 !== preg_match('/^\d+:\d+$/', $msg_number)) {

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -1423,7 +1423,7 @@ final class Imap
             throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.' must be a boolean, '.\gettype($allow_sequence).' given!');
         }
 
-        if (\is_int($msg_number)) {
+        if (\is_int($msg_number) || preg_match('/^\d+$/', $msg_number)) {
             return sprintf('%1$s:%1$s', $msg_number);
         } elseif (
             $allow_sequence &&

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -2,6 +2,7 @@
 
 namespace PhpImap;
 
+use function bin2hex;
 use function count;
 use DateTime;
 use Exception;
@@ -10,6 +11,7 @@ use InvalidArgumentException;
 use function mb_list_encodings;
 use PhpImap\Exceptions\ConnectionException;
 use PhpImap\Exceptions\InvalidParameterException;
+use function random_bytes;
 use Throwable;
 use UnexpectedValueException;
 
@@ -1304,7 +1306,7 @@ class Mailbox
      *
      * @param array  $params        Array of params of mail
      * @param object $partStructure Part of mail
-     * @param int    $mailId        ID of mail
+     * @param int    $_mailId       ID of mail
      * @param bool   $emlOrigin     True, if it indicates, that the attachment comes from an EML (mail) file
      *
      * @psalm-param array<string, string> $params
@@ -1314,7 +1316,7 @@ class Mailbox
      *
      * @todo consider "requiring" psalm (suggest + conflict) then setting $params to array<string, string>
      */
-    public function downloadAttachment(DataPartInfo $dataInfo, array $params, $partStructure, $mailId, $emlOrigin = false)
+    public function downloadAttachment(DataPartInfo $dataInfo, array $params, $partStructure, $_mailId, $emlOrigin = false)
     {
         if ('RFC822' == $partStructure->subtype && isset($partStructure->disposition) && 'attachment' == $partStructure->disposition) {
             $fileName = strtolower($partStructure->subtype).'.eml';
@@ -1350,13 +1352,7 @@ class Mailbox
         $attachmentsDir = $this->getAttachmentsDir();
 
         if (null != $attachmentsDir) {
-            $replace = [
-                '/\s/' => '_',
-                '/[^\w\.]/iu' => '',
-                '/_+/' => '_',
-                '/(^_)|(_$)/' => '',
-            ];
-            $fileSysName = preg_replace('~[\\\\/]~', '', (string) $mailId.'_'.$attachment->id.'_'.preg_replace(array_keys($replace), $replace, $fileName));
+            $fileSysName = bin2hex(random_bytes(16)).'.bin';
             $filePath = $attachmentsDir.\DIRECTORY_SEPARATOR.$fileSysName;
 
             if (\strlen($filePath) > 255) {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -998,23 +998,29 @@ class Mailbox
      *  SORTCC - mailbox in first cc address
      *  SORTSIZE - size of mail in octets
      *
-     * @param int    $criteria       Sorting criteria (eg. SORTARRIVAL)
-     * @param bool   $reverse        Sort reverse or not
-     * @param string $searchCriteria See http://php.net/imap_search for a complete list of available criteria
+     * @param int         $criteria       Sorting criteria (eg. SORTARRIVAL)
+     * @param bool        $reverse        Sort reverse or not
+     * @param string|null $searchCriteria See http://php.net/imap_search for a complete list of available criteria
+     * @param string|null $charset
      *
      * @psalm-param value-of<Imap::SORT_CRITERIA> $criteria
      * @psalm-param 1|5|0|2|6|3|4 $criteria
      *
      * @return array Mails ids
      */
-    public function sortMails($criteria = SORTARRIVAL, $reverse = true, $searchCriteria = 'ALL')
-    {
+    public function sortMails(
+        $criteria = SORTARRIVAL,
+        $reverse = true,
+        $searchCriteria = 'ALL',
+        $charset = null
+    ) {
         return Imap::sort(
             $this->getImapStream(),
             $criteria,
             $reverse,
             $this->imapSearchOption,
-            $searchCriteria
+            $searchCriteria,
+            $charset
         );
     }
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -180,14 +180,15 @@ class LiveMailboxTest extends TestCase
             ),
         ];
 
-        $random_subject = 'test: '.bin2hex(random_bytes(16));
+        $random_subject = 'barbushin/php-imap#448: dot first:'.bin2hex(random_bytes(16));
 
         yield [
             ['subject' => $random_subject],
             [
                 [
-                    'type' => TYPETEXT,
+                    'type' => TYPEAPPLICATION,
                     'encoding' => ENCBASE64,
+                    'subtype' => 'octet-stream',
                     'description' => '.gitignore',
                     'disposition.type' => 'attachment',
                     'disposition' => ['filename' => '.gitignore'],
@@ -200,10 +201,42 @@ class LiveMailboxTest extends TestCase
             (
                 'Subject: '.$random_subject."\r\n".
                 'MIME-Version: 1.0'."\r\n".
-                'Content-Type: TEXT/PLAIN; name=.gitignore'."\r\n".
+                'Content-Type: APPLICATION/octet-stream; name=.gitignore'."\r\n".
                 'Content-Transfer-Encoding: BASE64'."\r\n".
                 'Content-Description: .gitignore'."\r\n".
                 'Content-Disposition: attachment; filename=.gitignore'."\r\n".
+                "\r\n".
+                base64_encode(
+                    file_get_contents(__DIR__.'/../../.gitignore')
+                )."\r\n"
+            ),
+        ];
+
+        $random_subject = 'barbushin/php-imap#448: dot last: '.bin2hex(random_bytes(16));
+
+        yield [
+            ['subject' => $random_subject],
+            [
+                [
+                    'type' => TYPEAPPLICATION,
+                    'encoding' => ENCBASE64,
+                    'subtype' => 'octet-stream',
+                    'description' => 'gitignore.',
+                    'disposition.type' => 'attachment',
+                    'disposition' => ['filename' => 'gitignore.'],
+                    'type.parameters' => ['name' => 'gitignore.'],
+                    'contents.data' => base64_encode(
+                        file_get_contents(__DIR__.'/../../.gitignore')
+                    ),
+                ],
+            ],
+            (
+                'Subject: '.$random_subject."\r\n".
+                'MIME-Version: 1.0'."\r\n".
+                'Content-Type: APPLICATION/octet-stream; name=gitignore.'."\r\n".
+                'Content-Transfer-Encoding: BASE64'."\r\n".
+                'Content-Description: gitignore.'."\r\n".
+                'Content-Disposition: attachment; filename=gitignore.'."\r\n".
                 "\r\n".
                 base64_encode(
                     file_get_contents(__DIR__.'/../../.gitignore')
@@ -390,6 +423,17 @@ class LiveMailboxTest extends TestCase
                 ' then something has gone wrong.'
             )
         );
+
+        if (1 === preg_match(
+            '/^barbushin\/php-imap#448:/',
+            $envelope['subject']
+        )) {
+            static::assertTrue($mail->hasAttachments());
+
+            $attachments = $mail->getAttachments();
+
+            static::assertCount(1, $attachments);
+        }
 
         $mailbox->deleteMail($search[0]);
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -433,6 +433,11 @@ class LiveMailboxTest extends TestCase
             $attachments = $mail->getAttachments();
 
             static::assertCount(1, $attachments);
+
+            static::assertSame(
+                file_get_contents(__DIR__.'/../../.gitignore'),
+                current($attachments)->getContents()
+            );
         }
 
         $mailbox->deleteMail($search[0]);

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -7,10 +7,37 @@
  *
  * @author BAPCLTD-Marv
  */
-use ParagonIE\HiddenString\HiddenString;
-use PhpImap\Mailbox;
-use PHPUnit\Framework\TestCase;
 
+namespace PhpImap;
+
+use Exception;
+use Generator;
+use ParagonIE\HiddenString\HiddenString;
+use PHPUnit\Framework\TestCase;
+use const TYPETEXT;
+
+/**
+ * @psalm-type MAILBOX_ARGS = array{
+ *	0:HiddenString,
+ *	1:HiddenString,
+ *	2:HiddenString,
+ *	3:string,
+ *	4?:string
+ * }
+ * @psalm-type COMPOSE_ENVELOPE = array{
+ *	subject?:string
+ * }
+ * @psalm-type COMPOSE_BODY = list<array{
+ *	type?:int,
+ *	encoding?:int,
+ *	charset?:string,
+ *	subtype?:string,
+ *	description?:string,
+ *	disposition?:array{filename:string}
+ * }>
+ *
+ * @todo see @todo of Imap::mail_compose()
+ */
 class LiveMailboxTest extends TestCase
 {
     const RANDOM_MAILBOX_SAMPLE_SIZE = 3;
@@ -18,9 +45,7 @@ class LiveMailboxTest extends TestCase
     /**
      * Provides constructor arguments for a live mailbox.
      *
-     * @return array
-     *
-     * @psalm-return array{0:HiddenString, 1:HiddenString, 2:HiddenString, 3:string, 4?:string}[]
+     * @psalm-return MAILBOX_ARGS[]
      *
      * @todo drop php 5.6, add paragonie/hidden-string to require-dev
      */
@@ -38,7 +63,7 @@ class LiveMailboxTest extends TestCase
         $login = getenv('PHPIMAP_LOGIN');
         $password = getenv('PHPIMAP_PASSWORD');
 
-        if (is_string($imapPath) && is_string($login) && is_string($password)) {
+        if (\is_string($imapPath) && \is_string($login) && \is_string($password)) {
             $sets['CI ENV'] = [new HiddenString($imapPath), new HiddenString($login), new HiddenString($password, true, true), sys_get_temp_dir()];
         }
 
@@ -61,7 +86,7 @@ class LiveMailboxTest extends TestCase
         $exception = null;
 
         try {
-            $this->assertTrue(is_resource($mailbox->getImapStream()));
+            $this->assertTrue(\is_resource($mailbox->getImapStream()));
             $this->assertTrue($mailbox->hasImapStream());
 
             $mailboxes = $mailbox->getMailboxes();
@@ -69,12 +94,12 @@ class LiveMailboxTest extends TestCase
 
             $mailboxes = array_values($mailboxes);
 
-            $limit = min(count($mailboxes), self::RANDOM_MAILBOX_SAMPLE_SIZE);
+            $limit = min(\count($mailboxes), self::RANDOM_MAILBOX_SAMPLE_SIZE);
 
             for ($i = 0; $i < $limit; ++$i) {
-                static::assertTrue(is_array($mailboxes[$i]));
+                static::assertTrue(\is_array($mailboxes[$i]));
                 static::assertTrue(isset($mailboxes[$i]['shortpath']));
-                static::assertTrue(is_string($mailboxes[$i]['shortpath']));
+                static::assertTrue(\is_string($mailboxes[$i]['shortpath']));
                 $mailbox->switchMailbox($mailboxes[$i]['shortpath']);
 
                 $check = $mailbox->checkMailbox();
@@ -89,7 +114,7 @@ class LiveMailboxTest extends TestCase
                     $this->assertTrue(property_exists($check, $expectedProperty));
                 }
 
-                $this->assertTrue(is_string($check->Date), 'Date property of Mailbox::checkMailbox() result was not a string!');
+                $this->assertTrue(\is_string($check->Date), 'Date property of Mailbox::checkMailbox() result was not a string!');
 
                 $unix = strtotime($check->Date);
 
@@ -101,10 +126,10 @@ class LiveMailboxTest extends TestCase
                     $unix = strtotime(substr($check->Date, 0, $pos));
                 }
 
-                $this->assertTrue(is_int($unix), 'Date property of Mailbox::checkMailbox() result was not a valid date!');
-                $this->assertTrue(in_array($check->Driver, ['POP3', 'IMAP', 'NNTP', 'pop3', 'imap', 'nntp'], true), 'Driver property of Mailbox::checkMailbox() result was not of an expected value!');
-                $this->assertTrue(is_int($check->Nmsgs), 'Nmsgs property of Mailbox::checkMailbox() result was not of an expected type!');
-                $this->assertTrue(is_int($check->Recent), 'Recent property of Mailbox::checkMailbox() result was not of an expected type!');
+                $this->assertTrue(\is_int($unix), 'Date property of Mailbox::checkMailbox() result was not a valid date!');
+                $this->assertTrue(\in_array($check->Driver, ['POP3', 'IMAP', 'NNTP', 'pop3', 'imap', 'nntp'], true), 'Driver property of Mailbox::checkMailbox() result was not of an expected value!');
+                $this->assertTrue(\is_int($check->Nmsgs), 'Nmsgs property of Mailbox::checkMailbox() result was not of an expected type!');
+                $this->assertTrue(\is_int($check->Recent), 'Recent property of Mailbox::checkMailbox() result was not of an expected type!');
 
                 $status = $mailbox->statusMailbox();
 
@@ -129,5 +154,165 @@ class LiveMailboxTest extends TestCase
         if (null !== $exception) {
             throw $exception;
         }
+    }
+
+    /**
+     * @psalm-return list<array{0:COMPOSE_ENVELOPE, 1:COMPOSE_BODY, 2:string}>
+     */
+    public function ComposeProvider()
+    {
+        $random_subject = 'test: '.bin2hex(random_bytes(16));
+
+        return [
+            [
+                ['subject' => $random_subject],
+                [
+                    [
+                        'type' => TYPETEXT,
+                        'contents.data' => 'test',
+                    ],
+                ],
+                (
+                    'Subject: '.$random_subject."\r\n".
+                    'MIME-Version: 1.0'."\r\n".
+                    'Content-Type: TEXT/PLAIN; CHARSET=US-ASCII'."\r\n".
+                    "\r\n".
+                    'test'."\r\n"
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider ComposeProvider
+     *
+     * @param string $expected_result
+     *
+     * @psalm-param COMPOSE_ENVELOPE $envelope
+     * @psalm-param COMPOSE_BODY $body
+     *
+     * @return void
+     */
+    public function test_mail_compose(array $envelope, array $body, $expected_result)
+    {
+        static::assertSame($expected_result, Imap::mail_compose($envelope, $body));
+    }
+
+    /**
+     * @psalm-return Generator<int, array{
+     *	0:MAILBOX_ARGS,
+     *	1:COMPOSE_ENVELOPE,
+     *	2:COMPOSE_BODY,
+     *	3:bool
+     * }, mixed, void>
+     */
+    public function AppendProvider()
+    {
+        foreach ($this->MailBoxProvider() as $mailbox_args) {
+            foreach ($this->ComposeProvider() as $compose_args) {
+                list($envelope, $body) = $compose_args;
+
+                yield [$mailbox_args, $envelope, $body, false];
+                yield [$mailbox_args, $envelope, $body, true];
+            }
+        }
+    }
+
+    /**
+     * @dataProvider AppendProvider
+     *
+     * @depends testGetImapStream
+     * @depends test_mail_compose
+     *
+     * @param bool $pre_compose
+     *
+     * @psalm-param MAILBOX_ARGS $mailbox_args
+     * @psalm-param COMPOSE_ENVELOPE $envelope
+     * @psalm-param COMPOSE_BODY $body
+     *
+     * @return void
+     */
+    public function test_append(
+        array $mailbox_args,
+        array $envelope,
+        array $body,
+        $pre_compose
+    ) {
+        if (!isset($envelope['subject'])) {
+            static::markTestSkipped(
+                'Cannot search for message by subject, no subject specified!'
+            );
+
+            return;
+        }
+
+        static::assertTrue(\is_string(isset($envelope['subject']) ? $envelope['subject'] : null));
+
+        list($path, $username, $password, $attachments_dir) = $mailbox_args;
+
+        $mailbox = new Mailbox(
+            $path->getString(),
+            $username->getString(),
+            $password->getString(),
+            $attachments_dir,
+            isset($mailbox_args[4]) ? $mailbox_args[4] : 'UTF-8'
+        );
+
+        $search_criteria = sprintf('SUBJECT "%s"', $envelope['subject']);
+
+        static::assertCount(
+            0,
+            $mailbox->searchMailbox($search_criteria),
+            (
+                'If a subject was found,'.
+                ' then the message is insufficiently unique to assert that'.
+                ' a newly-appended message was actually created.'
+            )
+        );
+
+        $message = [$envelope, $body];
+
+        if ($pre_compose) {
+            $message = Imap::mail_compose($envelope, $body);
+        }
+
+        $mailbox->appendMessageToMailbox($message);
+
+        $search = $mailbox->searchMailbox($search_criteria);
+
+        static::assertCount(
+            1,
+            $search,
+            (
+                'If a subject was not found, '.
+                ' then Mailbox::appendMessageToMailbox() failed'.
+                ' despite not throwing an exception.'
+            )
+        );
+
+        $mail = $mailbox->getMail($search[0], false);
+
+        static::assertSame(
+            $envelope['subject'],
+            $mail->subject,
+            (
+                'If a retrieved mail did not have a matching subject'.
+                ' despite being found via search,'.
+                ' then something has gone wrong.'
+            )
+        );
+
+        $mailbox->deleteMail($search[0]);
+
+        $mailbox->expungeDeletedMails();
+
+        static::assertCount(
+            0,
+            $mailbox->searchMailbox($search_criteria),
+            (
+                'If a subject was found,'.
+                ' then the message is was not expunged as requested.'
+            )
+        );
     }
 }

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -76,6 +76,8 @@ class LiveMailboxTest extends TestCase
     /**
      * @dataProvider MailBoxProvider
      *
+     * @group live
+     *
      * @param string $attachmentsDir
      * @param string $serverEncoding
      *
@@ -293,6 +295,8 @@ class LiveMailboxTest extends TestCase
     /**
      * @dataProvider AppendProvider
      *
+     * @group live
+     *
      * @depends testGetImapStream
      * @depends test_mail_compose
      *
@@ -384,6 +388,8 @@ class LiveMailboxTest extends TestCase
 
     /**
      * @dataProvider AppendProvider
+     *
+     * @group live
      *
      * @depends test_append
      *
@@ -487,6 +493,8 @@ class LiveMailboxTest extends TestCase
 
     /**
      * @dataProvider AppendProvider
+     *
+     * @group live
      *
      * @depends test_append
      *
@@ -599,6 +607,8 @@ class LiveMailboxTest extends TestCase
 
     /**
      * @dataProvider AppendProvider
+     *
+     * @group live
      *
      * @depends test_append
      *

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -14,6 +14,7 @@ use Exception;
 use Generator;
 use ParagonIE\HiddenString\HiddenString;
 use PHPUnit\Framework\TestCase;
+use function random_int;
 use const TYPETEXT;
 use function usleep;
 
@@ -38,6 +39,7 @@ use function usleep;
  * }>
  *
  * @todo see @todo of Imap::mail_compose()
+ * @todo drop php 5.6, remove paragonie/random_compat
  */
 class LiveMailboxTest extends TestCase
 {
@@ -312,7 +314,7 @@ class LiveMailboxTest extends TestCase
             return;
         }
 
-        usleep(100);
+        usleep(random_int(100, 1000));
 
         static::assertTrue(\is_string(isset($envelope['subject']) ? $envelope['subject'] : null));
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -15,6 +15,7 @@ use Generator;
 use ParagonIE\HiddenString\HiddenString;
 use PHPUnit\Framework\TestCase;
 use const TYPETEXT;
+use function usleep;
 
 /**
  * @psalm-type MAILBOX_ARGS = array{
@@ -310,6 +311,8 @@ class LiveMailboxTest extends TestCase
 
             return;
         }
+
+        usleep(100);
 
         static::assertTrue(\is_string(isset($envelope['subject']) ? $envelope['subject'] : null));
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -163,53 +163,52 @@ class LiveMailboxTest extends TestCase
     {
         $random_subject = 'test: '.bin2hex(random_bytes(16));
 
-        yield
+        yield [
+            ['subject' => $random_subject],
             [
-                ['subject' => $random_subject],
                 [
-                    [
-                        'type' => TYPETEXT,
-                        'contents.data' => 'test',
-                    ],
+                    'type' => TYPETEXT,
+                    'contents.data' => 'test',
                 ],
-                (
-                    'Subject: '.$random_subject."\r\n".
-                    'MIME-Version: 1.0'."\r\n".
-                    'Content-Type: TEXT/PLAIN; CHARSET=US-ASCII'."\r\n".
-                    "\r\n".
-                    'test'."\r\n"
-                ),
+            ],
+            (
+                'Subject: '.$random_subject."\r\n".
+                'MIME-Version: 1.0'."\r\n".
+                'Content-Type: TEXT/PLAIN; CHARSET=US-ASCII'."\r\n".
+                "\r\n".
+                'test'."\r\n"
+            ),
         ];
 
         $random_subject = 'test: '.bin2hex(random_bytes(16));
 
         yield [
-                ['subject' => $random_subject],
+            ['subject' => $random_subject],
+            [
                 [
-                    [
-                        'type' => TYPETEXT,
-                        'encoding' => ENCBASE64,
-                        'description' => '.gitignore',
-                        'disposition.type' => 'attachment',
-                        'disposition' => ['filename' => '.gitignore'],
-                        'type.parameters' => ['name' => '.gitignore'],
-                        'contents.data' => base64_encode(
-                            file_get_contents(__DIR__.'/../../.gitignore')
-                        ),
-                    ],
-                ],
-                (
-                    'Subject: '.$random_subject."\r\n".
-                    'MIME-Version: 1.0'."\r\n".
-                    'Content-Type: TEXT/PLAIN; name=.gitignore'."\r\n".
-                    'Content-Transfer-Encoding: BASE64'."\r\n".
-                    'Content-Description: .gitignore'."\r\n".
-                    'Content-Disposition: attachment; filename=.gitignore'."\r\n".
-                    "\r\n".
-                    base64_encode(
+                    'type' => TYPETEXT,
+                    'encoding' => ENCBASE64,
+                    'description' => '.gitignore',
+                    'disposition.type' => 'attachment',
+                    'disposition' => ['filename' => '.gitignore'],
+                    'type.parameters' => ['name' => '.gitignore'],
+                    'contents.data' => base64_encode(
                         file_get_contents(__DIR__.'/../../.gitignore')
-                    )."\r\n"
-                ),
+                    ),
+                ],
+            ],
+            (
+                'Subject: '.$random_subject."\r\n".
+                'MIME-Version: 1.0'."\r\n".
+                'Content-Type: TEXT/PLAIN; name=.gitignore'."\r\n".
+                'Content-Transfer-Encoding: BASE64'."\r\n".
+                'Content-Description: .gitignore'."\r\n".
+                'Content-Disposition: attachment; filename=.gitignore'."\r\n".
+                "\r\n".
+                base64_encode(
+                    file_get_contents(__DIR__.'/../../.gitignore')
+                )."\r\n"
+            ),
         ];
     }
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -253,6 +253,8 @@ class LiveMailboxTest extends TestCase
     /**
      * @dataProvider ComposeProvider
      *
+     * @group compose
+     *
      * @param string $expected_result
      *
      * @psalm-param COMPOSE_ENVELOPE $envelope

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -530,8 +530,6 @@ class LiveMailboxTest extends TestCase
 
         $search_criteria = sprintf('SUBJECT "%s"', $envelope['subject']);
 
-        $count = $mailbox->countMails();
-
         $message = [$envelope, $body];
 
         if ($pre_compose) {
@@ -643,8 +641,6 @@ class LiveMailboxTest extends TestCase
         );
 
         $search_criteria = sprintf('SUBJECT "%s"', $envelope['subject']);
-
-        $count = $mailbox->countMails();
 
         $message = [$envelope, $body];
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -180,6 +180,34 @@ class LiveMailboxTest extends TestCase
                     'test'."\r\n"
                 ),
             ],
+            [
+                ['subject' => $random_subject],
+                [
+                    [
+                        'type' => TYPETEXT,
+                        'encoding' => ENCBASE64,
+                        'description' => '.gitignore',
+                        'disposition.type' => 'attachment',
+                        'disposition' => ['filename' => '.gitignore'],
+                        'type.parameters' => ['name' => '.gitignore'],
+                        'contents.data' => base64_encode(
+                            file_get_contents(__DIR__.'/../../.gitignore')
+                        ),
+                    ],
+                ],
+                (
+                    'Subject: '.$random_subject."\r\n".
+                    'MIME-Version: 1.0'."\r\n".
+                    'Content-Type: TEXT/PLAIN; name=.gitignore'."\r\n".
+                    'Content-Transfer-Encoding: BASE64'."\r\n".
+                    'Content-Description: .gitignore'."\r\n".
+                    'Content-Disposition: attachment; filename=.gitignore'."\r\n".
+                    "\r\n".
+                    base64_encode(
+                        file_get_contents(__DIR__.'/../../.gitignore')
+                    )."\r\n"
+                ),
+            ],
         ];
     }
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -279,6 +279,12 @@ class LiveMailboxTest extends TestCase
                 list($envelope, $body, $expected_compose_result) = $compose_args;
 
                 yield [$mailbox_args, $envelope, $body, $expected_compose_result, false];
+            }
+
+            foreach ($this->ComposeProvider() as $compose_args) {
+                list($envelope, $body, $expected_compose_result) = $compose_args;
+
+                yield [$mailbox_args, $envelope, $body, $expected_compose_result, false];
                 yield [$mailbox_args, $envelope, $body, $expected_compose_result, true];
             }
         }

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -157,13 +157,13 @@ class LiveMailboxTest extends TestCase
     }
 
     /**
-     * @psalm-return list<array{0:COMPOSE_ENVELOPE, 1:COMPOSE_BODY, 2:string}>
+     * @psalm-return Generator<int, array{0:COMPOSE_ENVELOPE, 1:COMPOSE_BODY, 2:string}, mixed, void>
      */
     public function ComposeProvider()
     {
         $random_subject = 'test: '.bin2hex(random_bytes(16));
 
-        return [
+        yield
             [
                 ['subject' => $random_subject],
                 [
@@ -179,8 +179,11 @@ class LiveMailboxTest extends TestCase
                     "\r\n".
                     'test'."\r\n"
                 ),
-            ],
-            [
+        ];
+
+        $random_subject = 'test: '.bin2hex(random_bytes(16));
+
+        yield [
                 ['subject' => $random_subject],
                 [
                     [
@@ -207,7 +210,6 @@ class LiveMailboxTest extends TestCase
                         file_get_contents(__DIR__.'/../../.gitignore')
                     )."\r\n"
                 ),
-            ],
         ];
     }
 

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -203,7 +203,8 @@ class LiveMailboxTest extends TestCase
      *	0:MAILBOX_ARGS,
      *	1:COMPOSE_ENVELOPE,
      *	2:COMPOSE_BODY,
-     *	3:bool
+     *	3:string,
+     *	4:bool
      * }, mixed, void>
      */
     public function AppendProvider()

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -296,7 +296,7 @@ class LiveMailboxTest extends TestCase
      * @depends testGetImapStream
      * @depends test_mail_compose
      *
-     * @param string $expected_compose_result
+     * @param string $_expected_compose_result
      * @param bool   $pre_compose
      *
      * @psalm-param MAILBOX_ARGS $mailbox_args
@@ -309,7 +309,7 @@ class LiveMailboxTest extends TestCase
         array $mailbox_args,
         array $envelope,
         array $body,
-        $expected_compose_result,
+        $_expected_compose_result,
         $pre_compose
     ) {
         if (!isset($envelope['subject'])) {
@@ -387,7 +387,7 @@ class LiveMailboxTest extends TestCase
      *
      * @depends test_append
      *
-     * @param string $expected_compose_result
+     * @param string $_expected_compose_result
      * @param bool   $pre_compose
      *
      * @psalm-param MAILBOX_ARGS $mailbox_args
@@ -400,7 +400,7 @@ class LiveMailboxTest extends TestCase
         array $mailbox_args,
         array $envelope,
         array $body,
-        $expected_compose_result,
+        $_expected_compose_result,
         $pre_compose
     ) {
         if (!isset($envelope['subject'])) {
@@ -490,7 +490,7 @@ class LiveMailboxTest extends TestCase
      *
      * @depends test_append
      *
-     * @param string $expected_compose_result
+     * @param string $_expected_compose_result
      * @param bool   $pre_compose
      *
      * @psalm-param MAILBOX_ARGS $mailbox_args
@@ -503,7 +503,7 @@ class LiveMailboxTest extends TestCase
         array $mailbox_args,
         array $envelope,
         array $body,
-        $expected_compose_result,
+        $_expected_compose_result,
         $pre_compose
     ) {
         if (!isset($envelope['subject'])) {

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -18,13 +18,6 @@ final class MailboxTest extends TestCase
     const ANYTHING = 0;
 
     /**
-     * Holds a PhpImap\Mailbox instance.
-     *
-     * @var Mailbox
-     */
-    private $mailbox;
-
-    /**
      * Holds the imap path.
      *
      * @var string
@@ -62,26 +55,6 @@ final class MailboxTest extends TestCase
     private $serverEncoding = 'UTF-8';
 
     /**
-     * Run before each test is started.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $this->mailbox = new Mailbox($this->imapPath, $this->login, $this->password, $this->attachmentsDir, $this->serverEncoding);
-    }
-
-    /**
-     * Test, that the constructor returns an instance of PhpImap\Mailbox::class.
-     *
-     * @return void
-     */
-    public function testConstructor()
-    {
-        $this->assertInstanceOf(Mailbox::class, $this->mailbox);
-    }
-
-    /**
      * Test, that the constructor trims possible variables
      * Leading and ending spaces are not even possible in some variables.
      *
@@ -112,9 +85,11 @@ final class MailboxTest extends TestCase
      */
     public function testSetAndGetServerEncoding()
     {
-        $this->mailbox->setServerEncoding('UTF-8');
+        $mailbox = $this->getMailbox();
 
-        $this->assertEquals($this->mailbox->getServerEncoding(), 'UTF-8');
+        $mailbox->setServerEncoding('UTF-8');
+
+        $this->assertEquals($mailbox->getServerEncoding(), 'UTF-8');
     }
 
     /**
@@ -185,13 +160,15 @@ final class MailboxTest extends TestCase
      */
     public function testServerEncodingOnlyUseSupportedSettings($bool, $encoding)
     {
+        $mailbox = $this->getMailbox();
+
         if ($bool) {
-            $this->mailbox->setServerEncoding($encoding);
-            $this->assertEquals($encoding, $this->mailbox->getServerEncoding());
+            $mailbox->setServerEncoding($encoding);
+            $this->assertEquals($encoding, $mailbox->getServerEncoding());
         } else {
             $this->expectException(InvalidParameterException::class);
-            $this->mailbox->setServerEncoding($encoding);
-            $this->assertNotEquals($encoding, $this->mailbox->getServerEncoding());
+            $mailbox->setServerEncoding($encoding);
+            $this->assertNotEquals($encoding, $mailbox->getServerEncoding());
         }
     }
 
@@ -204,7 +181,7 @@ final class MailboxTest extends TestCase
      */
     public function testImapSearchOptionHasADefault()
     {
-        $this->assertEquals($this->mailbox->getImapSearchOption(), 1);
+        $this->assertEquals($this->getMailbox()->getImapSearchOption(), 1);
     }
 
     /**
@@ -216,14 +193,16 @@ final class MailboxTest extends TestCase
      */
     public function testSetAndGetImapSearchOption()
     {
-        $this->mailbox->setImapSearchOption(SE_FREE);
-        $this->assertEquals($this->mailbox->getImapSearchOption(), 2);
+        $mailbox = $this->getMailbox();
+
+        $mailbox->setImapSearchOption(SE_FREE);
+        $this->assertEquals($mailbox->getImapSearchOption(), 2);
 
         $this->expectException(InvalidParameterException::class);
-        $this->mailbox->setImapSearchOption(self::ANYTHING);
+        $mailbox->setImapSearchOption(self::ANYTHING);
 
-        $this->mailbox->setImapSearchOption(SE_UID);
-        $this->assertEquals($this->mailbox->getImapSearchOption(), 1);
+        $mailbox->setImapSearchOption(SE_UID);
+        $this->assertEquals($mailbox->getImapSearchOption(), 1);
     }
 
     /**
@@ -233,7 +212,7 @@ final class MailboxTest extends TestCase
      */
     public function testGetLogin()
     {
-        $this->assertEquals($this->mailbox->getLogin(), 'php-imap@example.com');
+        $this->assertEquals($this->getMailbox()->getLogin(), 'php-imap@example.com');
     }
 
     /**
@@ -243,7 +222,7 @@ final class MailboxTest extends TestCase
      */
     public function testPathDelimiterHasADefault()
     {
-        $this->assertNotEmpty($this->mailbox->getPathDelimiter());
+        $this->assertNotEmpty($this->getMailbox()->getPathDelimiter());
     }
 
     /**
@@ -328,11 +307,13 @@ final class MailboxTest extends TestCase
     {
         $supported_delimiters = ['.', '/'];
 
+        $mailbox = $this->getMailbox();
+
         if (\in_array($str, $supported_delimiters)) {
-            $this->assertTrue($this->mailbox->validatePathDelimiter($str));
+            $this->assertTrue($mailbox->validatePathDelimiter($str));
         } else {
             $this->expectException(InvalidParameterException::class);
-            $this->mailbox->setPathDelimiter($str);
+            $mailbox->setPathDelimiter($str);
         }
     }
 
@@ -343,11 +324,13 @@ final class MailboxTest extends TestCase
      */
     public function testSetAndGetPathDelimiter()
     {
-        $this->mailbox->setPathDelimiter('.');
-        $this->assertEquals($this->mailbox->getPathDelimiter(), '.');
+        $mailbox = $this->getMailbox();
 
-        $this->mailbox->setPathDelimiter('/');
-        $this->assertEquals($this->mailbox->getPathDelimiter(), '/');
+        $mailbox->setPathDelimiter('.');
+        $this->assertEquals($mailbox->getPathDelimiter(), '.');
+
+        $mailbox->setPathDelimiter('/');
+        $this->assertEquals($mailbox->getPathDelimiter(), '/');
     }
 
     /**
@@ -357,7 +340,7 @@ final class MailboxTest extends TestCase
      */
     public function testGetAttachmentsAreNotIgnoredByDefault()
     {
-        $this->assertEquals($this->mailbox->getAttachmentsIgnore(), false);
+        $this->assertEquals($this->getMailbox()->getAttachmentsIgnore(), false);
     }
 
     /**
@@ -391,12 +374,14 @@ final class MailboxTest extends TestCase
      */
     public function testSetAttachmentsIgnore($assertTest, $paramValue)
     {
+        $mailbox = $this->getMailbox();
+
         if ('expectException' == $assertTest) {
             $this->expectException(InvalidParameterException::class);
-            $this->mailbox->setAttachmentsIgnore($paramValue);
+            $mailbox->setAttachmentsIgnore($paramValue);
         } else {
-            $this->mailbox->setAttachmentsIgnore((bool) $paramValue);
-            $this->assertEquals($this->mailbox->getAttachmentsIgnore(), (bool) $paramValue);
+            $mailbox->setAttachmentsIgnore((bool) $paramValue);
+            $this->assertEquals($mailbox->getAttachmentsIgnore(), (bool) $paramValue);
         }
     }
 
@@ -451,8 +436,10 @@ final class MailboxTest extends TestCase
      */
     public function testEncodingToUtf7DecodeBackToUtf8($str)
     {
-        $utf7_encoded_str = $this->mailbox->encodeStringToUtf7Imap($str);
-        $utf8_decoded_str = $this->mailbox->decodeStringFromUtf7ImapToUtf8($utf7_encoded_str);
+        $mailbox = $this->getMailbox();
+
+        $utf7_encoded_str = $mailbox->encodeStringToUtf7Imap($str);
+        $utf8_decoded_str = $mailbox->decodeStringFromUtf7ImapToUtf8($utf7_encoded_str);
 
         $this->assertEquals($utf8_decoded_str, $str);
     }
@@ -468,7 +455,7 @@ final class MailboxTest extends TestCase
      */
     public function testMimeDecodingReturnsCorrectValues($str)
     {
-        $this->assertEquals($this->mailbox->decodeMimeStr($str, 'utf-8'), $str);
+        $this->assertEquals($this->getMailbox()->decodeMimeStr($str, 'utf-8'), $str);
     }
 
     /**
@@ -508,7 +495,7 @@ final class MailboxTest extends TestCase
      */
     public function testParsedDateDifferentTimeZones($dateToParse, $epochToCompare)
     {
-        $parsedDt = $this->mailbox->parseDateTime($dateToParse);
+        $parsedDt = $this->getMailbox()->parseDateTime($dateToParse);
         $parsedDateTime = new DateTime($parsedDt);
         $this->assertEquals($parsedDateTime->format('U'), $epochToCompare);
     }
@@ -538,7 +525,7 @@ final class MailboxTest extends TestCase
      */
     public function testParsedDateWithUnparseableDateTime($dateToParse)
     {
-        $parsedDt = $this->mailbox->parseDateTime($dateToParse);
+        $parsedDt = $this->getMailbox()->parseDateTime($dateToParse);
         $this->assertEquals($parsedDt, $dateToParse);
     }
 
@@ -550,7 +537,7 @@ final class MailboxTest extends TestCase
     public function testParsedDateTimeWithEmptyHeaderDate()
     {
         $this->expectException(InvalidParameterException::class);
-        $this->mailbox->parseDateTime('');
+        $this->getMailbox()->parseDateTime('');
     }
 
     /**
@@ -586,11 +573,13 @@ final class MailboxTest extends TestCase
      */
     public function testMimeEncoding($str, $expected)
     {
+        $mailbox = $this->getMailbox();
+
         if (empty($expected)) {
             $this->expectException(Exception::class);
-            $this->mailbox->decodeMimeStr($str);
+            $mailbox->decodeMimeStr($str);
         } else {
-            $this->assertEquals($this->mailbox->decodeMimeStr($str), $expected);
+            $this->assertEquals($mailbox->decodeMimeStr($str), $expected);
         }
     }
 
@@ -632,11 +621,13 @@ final class MailboxTest extends TestCase
      */
     public function testSetTimeouts($assertMethod, $timeout, $types)
     {
+        $mailbox = $this->getMailbox();
+
         if ('expectException' == $assertMethod) {
             $this->expectException(InvalidParameterException::class);
-            $this->mailbox->setTimeouts($timeout, $types);
+            $mailbox->setTimeouts($timeout, $types);
         } else {
-            $this->assertNull($this->mailbox->setTimeouts($timeout, $types));
+            $this->assertNull($mailbox->setTimeouts($timeout, $types));
         }
     }
 
@@ -689,11 +680,13 @@ final class MailboxTest extends TestCase
      */
     public function testSetConnectionArgs($assertMethod, $option, $retriesNum, $param)
     {
+        $mailbox = $this->getMailbox();
+
         if ('expectException' == $assertMethod) {
             $this->expectException(InvalidParameterException::class);
-            $this->mailbox->setConnectionArgs($option, $retriesNum, $param);
+            $mailbox->setConnectionArgs($option, $retriesNum, $param);
         } elseif ('assertNull' == $assertMethod) {
-            $this->assertNull($this->mailbox->setConnectionArgs($option, $retriesNum, $param));
+            $this->assertNull($mailbox->setConnectionArgs($option, $retriesNum, $param));
         }
     }
 
@@ -731,8 +724,10 @@ final class MailboxTest extends TestCase
      */
     public function testDecodeMimeStr($str, $expectedStr, $serverEncoding = 'utf-8')
     {
-        $this->mailbox->setServerEncoding($serverEncoding);
-        $this->assertEquals($this->mailbox->decodeMimeStr($str, $this->mailbox->getServerEncoding()), $expectedStr);
+        $mailbox = $this->getMailbox();
+
+        $mailbox->setServerEncoding($serverEncoding);
+        $this->assertEquals($mailbox->decodeMimeStr($str, $mailbox->getServerEncoding()), $expectedStr);
     }
 
     /**
@@ -786,5 +781,13 @@ final class MailboxTest extends TestCase
         $this->expectExceptionMessage($expectedExceptionMessage);
 
         $mailbox->setAttachmentsDir($attachmentsDir);
+    }
+
+    /**
+     * @return Mailbox
+     */
+    protected function getMailbox()
+    {
+        return new Mailbox($this->imapPath, $this->login, $this->password, $this->attachmentsDir, $this->serverEncoding);
     }
 }


### PR DESCRIPTION
backporting changes to the Imap class

* adds Imap::mail_compose(), Imap::append()
* fleshes out test coverage by testing compose, append, search & delete
* types still need fleshing out pending vimeo/psalm#1518
* fixes bugs
* increases test coverage