### PR TITLE
rewrite how travis tasks are run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,60 @@ env:
     - CC_TEST_REPORTER_ID=4eed0d135b9e1a1668a68e5e29cc71faf872937d13c42efa4faf42dad5ed3375
 
 language: php
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      dist: xenial
+      env:
+        - analysis=no
+        - coverage=no
+    - php: 7.0
+      dist: xenial
+      env:
+        - analysis=no
+        - coverage=no
+    - php: 7.1
+      dist: xenial
+      env:
+        - analysis=no
+        - coverage=no
+    - php: 7.2
+      dist: xenial
+      env:
+        - analysis=yes
+        - coverage=no
+    - php: 7.3
+      dist: xenial
+      env:
+        - analysis=yes
+        - coverage=no
+    - php: 7.4
+      dist: bionic
+      env:
+        - analysis=yes
+        - coverage=yes
+
+cache:
+  directories:
+    - ./vendor
 
 before_script:
+  - if [[ "$coverage" = "no" ]]; then phpenv config-rm xdebug.ini; fi
   - composer install --no-interaction
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - if [[ "$coverage" = "yes" ]]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
+  - if [[ "$coverage" = "yes" ]]; then chmod +x ./cc-test-reporter; fi
+  - if [[ "$coverage" = "yes" ]]; then ./cc-test-reporter before-build; fi
+  - if [[ "$analysis" = "yes" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit maglnet/composer-require-checker:^2.0 paragonie/hidden-string; fi
 
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
-  - vendor/bin/phpunit --coverage-php=coverage/not-live.cov --stop-on-failure --exclude-group=live
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit symfony/console:^4 phpunit/phpcov maglnet/composer-require-checker:^2.0 paragonie/hidden-string; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then vendor/bin/phpunit --coverage-php=coverage/live.cov --stop-on-failure --group=live,compose; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/composer-require-checker check ./composer.json; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then ./vendor/bin/psalm --show-info=false --shepherd; fi
-  - vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v
-  - vendor/bin/phpcov merge ./coverage/ --clover clover.xml
+  - if [[ "$coverage" = "no" ]]; then vendor/bin/phpunit --stop-on-failure --exclude-group=live; fi
+  - if [[ "$coverage" = "yes" ]]; then vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure; fi
+  - if [[ "$analysis" = "yes" ]]; then vendor/bin/composer-require-checker check ./composer.json; fi
+  - if [[ "$analysis" = "yes" ]]; then vendor/bin/psalm --show-info=false --shepherd; fi
+  - if [[ "$analysis" = "yes" ]]; then vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v; fi
 
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover
+  - if [[ "$coverage" = "yes" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover; fi

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "friendsofphp/php-cs-fixer": "^2.16",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "paragonie/random_compat": "^1",
-        "phpunit/phpcov": "^3",
         "phpunit/phpunit": "^5.7"
     },
     "suggest": {


### PR DESCRIPTION
* uses env to as control rather than php version
* unloads xdebug when not running coverage
* only fetches cc-test-reporter when running coverage
* drops phpcov merging in favour of only running coverage on php 7.4