### PR TITLE
Modify/live tests use random mailbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,31 +12,38 @@ matrix:
       env:
         - analysis=no
         - coverage=no
+        - hiddenstring=no
+        - phpunitflags="--stop-on-failure --exclude-group=live"
     - php: 7.0
       dist: xenial
       env:
         - analysis=no
         - coverage=no
+        - phpunitflags="--stop-on-failure"
     - php: 7.1
       dist: xenial
       env:
         - analysis=no
         - coverage=no
+        - phpunitflags="--stop-on-failure"
     - php: 7.2
       dist: xenial
       env:
         - analysis=yes
         - coverage=no
+        - phpunitflags="--stop-on-failure"
     - php: 7.3
       dist: xenial
       env:
         - analysis=yes
         - coverage=no
+        - phpunitflags="--stop-on-failure"
     - php: 7.4
       dist: bionic
       env:
         - analysis=yes
         - coverage=yes
+        - phpunitflags="--stop-on-failure --coverage-clover=clover.xml"
 
 cache:
   directories:
@@ -48,12 +55,12 @@ before_script:
   - if [[ "$coverage" = "yes" ]]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
   - if [[ "$coverage" = "yes" ]]; then chmod +x ./cc-test-reporter; fi
   - if [[ "$coverage" = "yes" ]]; then ./cc-test-reporter before-build; fi
-  - if [[ "$analysis" = "yes" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit maglnet/composer-require-checker:^2.0 paragonie/hidden-string; fi
+  - if [[ "$hiddenstring" != "no" ]]; then composer require --dev paragonie/hidden-string; fi
+  - if [[ "$analysis" = "yes" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit maglnet/composer-require-checker:^2.0; fi
 
 script:
   - vendor/bin/parallel-lint .php_cs.dist src tests examples
-  - if [[ "$coverage" = "no" ]]; then vendor/bin/phpunit --stop-on-failure --exclude-group=live; fi
-  - if [[ "$coverage" = "yes" ]]; then vendor/bin/phpunit --coverage-clover=clover.xml --stop-on-failure; fi
+  - vendor/bin/phpunit $phpunitflags
   - if [[ "$analysis" = "yes" ]]; then vendor/bin/composer-require-checker check ./composer.json; fi
   - if [[ "$analysis" = "yes" ]]; then vendor/bin/psalm --show-info=false --shepherd; fi
   - if [[ "$analysis" = "yes" ]]; then vendor/bin/php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v; fi

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -150,10 +150,11 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="tests/unit/LiveMailboxTest.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument occurrences="4">
       <code>random_bytes(16)</code>
       <code>random_bytes(16)</code>
       <code>random_bytes(16)</code>
+      <code>random_bytes(4)</code>
     </InvalidArgument>
     <PossiblyNullArgument occurrences="5">
       <code>$envelope['subject']</code>

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -564,6 +564,16 @@ final class Imap
         );
 
         if (false === $result) {
+            $errors = imap_errors();
+
+            if (false === $errors) {
+                /*
+                * if there were no errors then there were no mailboxes,
+                *  rather than a failure to get mailboxes.
+                */
+                return [];
+            }
+
             throw new UnexpectedValueException('Call to imap_getmailboxes() with supplied arguments returned false, not array!', 0, self::HandleErrors(imap_errors(), 'imap_headers'));
         }
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -521,17 +521,18 @@ class Mailbox
      * Switch mailbox without opening a new connection.
      *
      * @param string $imapPath
+     * @param bool   $absolute
      *
      * @return void
      *
      * @throws Exception
      */
-    public function switchMailbox($imapPath)
+    public function switchMailbox($imapPath, $absolute = true)
     {
         if (strpos($imapPath, '}') > 0) {
             $this->imapPath = $imapPath;
         } else {
-            $this->imapPath = $this->getCombinedPath($imapPath, true);
+            $this->imapPath = $this->getCombinedPath($imapPath, $absolute);
         }
 
         Imap::reopen($this->getImapStream(), $this->imapPath);
@@ -597,15 +598,16 @@ class Mailbox
     /**
      * Deletes a specific mailbox.
      *
-     * @param string $name Name of mailbox, which you want to delete (eg. 'PhpImap')
+     * @param string $name     Name of mailbox, which you want to delete (eg. 'PhpImap')
+     * @param bool   $absolute
      *
      * @return bool
      *
      * @see   imap_deletemailbox()
      */
-    public function deleteMailbox($name)
+    public function deleteMailbox($name, $absolute = false)
     {
-        return Imap::deletemailbox($this->getImapStream(), $this->getCombinedPath($name));
+        return Imap::deletemailbox($this->getImapStream(), $this->getCombinedPath($name, $absolute));
     }
 
     /**

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -15,9 +15,8 @@ use Exception;
 use Generator;
 use ParagonIE\HiddenString\HiddenString;
 use PHPUnit\Framework\TestCase;
-use function random_int;
+use function random_bytes;
 use const TYPETEXT;
-use function usleep;
 
 /**
  * @psalm-type MAILBOX_ARGS = array{
@@ -334,8 +333,6 @@ class LiveMailboxTest extends TestCase
             return;
         }
 
-        usleep(random_int(100, 1000));
-
         static::assertTrue(\is_string(isset($envelope['subject']) ? $envelope['subject'] : null));
 
         list($path, $username, $password, $attachments_dir) = $mailbox_args;
@@ -429,8 +426,6 @@ class LiveMailboxTest extends TestCase
 
             return;
         }
-
-        usleep(random_int(100, 1000));
 
         static::assertTrue(\is_string(isset($envelope['subject']) ? $envelope['subject'] : null));
 
@@ -537,8 +532,6 @@ class LiveMailboxTest extends TestCase
 
             return;
         }
-
-        usleep(random_int(100, 1000));
 
         static::assertTrue(\is_string(isset($envelope['subject']) ? $envelope['subject'] : null));
 
@@ -654,8 +647,6 @@ class LiveMailboxTest extends TestCase
 
             return;
         }
-
-        usleep(random_int(100, 1000));
 
         static::assertTrue(\is_string(isset($envelope['subject']) ? $envelope['subject'] : null));
 


### PR DESCRIPTION
running the `@group live` tests on multiple builds seems to be less failure-prone now, but it does extend the run time of each job they're running on.