### PR TITLE
waiting for builds to finish is tedious

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,32 +12,31 @@ matrix:
       env:
         - analysis=no
         - coverage=no
-        - hiddenstring=no
         - phpunitflags="--stop-on-failure --exclude-group=live"
     - php: 7.0
       dist: xenial
       env:
         - analysis=no
         - coverage=no
-        - phpunitflags="--stop-on-failure"
+        - phpunitflags="--stop-on-failure --exclude-group=live"
     - php: 7.1
       dist: xenial
       env:
         - analysis=no
         - coverage=no
-        - phpunitflags="--stop-on-failure"
+        - phpunitflags="--stop-on-failure --exclude-group=live"
     - php: 7.2
       dist: xenial
       env:
-        - analysis=yes
+        - analysis=no
         - coverage=no
-        - phpunitflags="--stop-on-failure"
+        - phpunitflags="--stop-on-failure --exclude-group=live"
     - php: 7.3
       dist: xenial
       env:
-        - analysis=yes
+        - analysis=no
         - coverage=no
-        - phpunitflags="--stop-on-failure"
+        - phpunitflags="--stop-on-failure --exclude-group=live"
     - php: 7.4
       dist: bionic
       env:
@@ -55,7 +54,7 @@ before_script:
   - if [[ "$coverage" = "yes" ]]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
   - if [[ "$coverage" = "yes" ]]; then chmod +x ./cc-test-reporter; fi
   - if [[ "$coverage" = "yes" ]]; then ./cc-test-reporter before-build; fi
-  - if [[ "$hiddenstring" != "no" ]]; then composer require --dev paragonie/hidden-string; fi
+  - if [[ "$analysis" = "yes" ]]; then composer require --dev paragonie/hidden-string; fi
   - if [[ "$analysis" = "yes" ]]; then composer require --dev --update-with-dependencies friendsofphp/php-cs-fixer phpunit/phpunit vimeo/psalm psalm/plugin-phpunit maglnet/composer-require-checker:^2.0; fi
 
 script:

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -83,7 +83,6 @@
       <code>\is_int($argument)</code>
       <code>\is_bool($allow_sequence)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1"/>
     <MixedReturnTypeCoercion occurrences="2">
       <code>$result</code>
       <code>array[]</code>

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -291,15 +291,22 @@ final class Imap
             throw new InvalidArgumentException('Argument 3 passed to '.__METHOD__.'() must be an integer, '.\gettype($options).' given!');
         }
 
+        /**
+         * @var int
+         *
+         * @todo remove docblock pending resolution of https://github.com/vimeo/psalm/issues/2620
+         */
+        $msg_number = self::encodeStringToUtf7Imap(self::EnsureRange(
+            $msg_number,
+            __METHOD__,
+            1
+        ));
+
         imap_errors(); // flush errors
 
         $result = imap_delete(
             self::EnsureResource($imap_stream, __METHOD__, 1),
-            self::encodeStringToUtf7Imap(self::EnsureRange(
-                $msg_number,
-                __METHOD__,
-                1
-            )),
+            $msg_number,
             $options
         );
 


### PR DESCRIPTION
as mentioned in #460, waiting for travis to run the `@group live` tests is tedious.

since #460 also shifted coverage generation solely onto php 7.4, it speeds things up a little to exclude the `@group live` tests from everywhere *except* php 7.4.

as `paragonie/hidden-string` is only (currently) required for the live tests, builds can be sped up a non-zero amount by not installing it.