### PR TITLE
adding script to run tests locally

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.yml]
 indent_size = 2
+
+[composer.json]
+indent_style = space

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,15 @@
         "paragonie/random_compat": "^1",
         "phpunit/phpunit": "^5.7"
     },
+    "scripts": {
+        "tests": [
+            "parallel-lint .php_cs.dist src tests examples",
+            "phpunit",
+            "composer-require-checker check ./composer.json",
+            "psalm --show-info=false",
+            "php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v"
+        ]
+    },
     "suggest": {
         "ext-fileinfo": "To facilitate IncomingMailAttachment::getMimeType() auto-detection"
     },


### PR DESCRIPTION
added because manually copying & pasting lines from the travis config was becoming tedious.