### PR TITLE
fixes #499

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.3
 
 env:
-  - phpunitflags="--stop-on-failure --exclude-group=live"
+  - phpunitflags="--stop-on-failure --exclude-group=live,live-manual"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.3
 
 env:
-  - phpunitflags="--stop-on-failure --exclude-group=live,live-manual"
+  - phpunitflags="--stop-on-failure --testdox --exclude-group=live,live-manual"
 
 matrix:
   fast_finish: true
@@ -30,7 +30,7 @@ matrix:
       env:
         - lint=no
         - coverage=yes
-        - phpunitflags="--stop-on-failure --coverage-clover=clover.xml"
+        - phpunitflags="--stop-on-failure --testdox --coverage-clover=clover.xml"
 
 cache:
   directories:

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -691,7 +691,7 @@ final class Imap
             $mailbox_name = $matches[1];
 
             if (!\mb_detect_encoding($mailbox_name, 'ASCII', true)) {
-                $mailbox = static::encodeStringToUtf7Imap($mailbox_name);
+                $mailbox = static::encodeStringToUtf7Imap($mailbox);
             }
         }
 

--- a/tests/unit/AbstractLiveMailboxTest.php
+++ b/tests/unit/AbstractLiveMailboxTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Live Mailbox - PHPUnit tests.
+ *
+ * Runs tests on a live mailbox
+ *
+ * @author BAPCLTD-Marv
+ */
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use ParagonIE\HiddenString\HiddenString;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-type MAILBOX_ARGS = array{
+ *	0:HiddenString,
+ *	1:HiddenString,
+ *	2:HiddenString,
+ *	3:string,
+ *	4?:string
+ * }
+ */
+abstract class AbstractLiveMailboxTest extends TestCase
+{
+    /**
+     * Provides constructor arguments for a live mailbox.
+     *
+     * @psalm-return MAILBOX_ARGS[]
+     */
+    public function MailBoxProvider(): array
+    {
+        $sets = [];
+
+        $imapPath = \getenv('PHPIMAP_IMAP_PATH');
+        $login = \getenv('PHPIMAP_LOGIN');
+        $password = \getenv('PHPIMAP_PASSWORD');
+
+        if (\is_string($imapPath) && \is_string($login) && \is_string($password)) {
+            $sets['CI ENV'] = [new HiddenString($imapPath), new HiddenString($login), new HiddenString($password, true, true), \sys_get_temp_dir()];
+        }
+
+        return $sets;
+    }
+
+    /**
+     * Get instance of Mailbox, pre-set to a random mailbox.
+     *
+     * @param string $attachmentsDir
+     * @param string $serverEncoding
+     *
+     * @return mixed[]
+     *
+     * @psalm-return array{0:Mailbox, 1:string, 2:HiddenString}
+     */
+    protected function getMailbox(HiddenString $imapPath, HiddenString $login, HiddenString $password, $attachmentsDir, $serverEncoding = 'UTF-8')
+    {
+        $mailbox = new Mailbox($imapPath->getString(), $login->getString(), $password->getString(), $attachmentsDir, $serverEncoding);
+
+        $random = 'test-box-'.\date('c').\bin2hex(\random_bytes(4));
+
+        $mailbox->createMailbox($random);
+
+        $mailbox->switchMailbox($random, false);
+
+        return [$mailbox, $random, $imapPath];
+    }
+
+    /**
+     * @psalm-param MAILBOX_ARGS $mailbox_args
+     *
+     * @return mixed[]
+     *
+     * @psalm-return array{0:Mailbox, 1:string, 2:HiddenString}
+     */
+    protected function getMailboxFromArgs(array $mailbox_args): array
+    {
+        list($path, $username, $password, $attachments_dir) = $mailbox_args;
+
+        return $this->getMailbox(
+            $path,
+            $username,
+            $password,
+            $attachments_dir,
+            isset($mailbox_args[4]) ? $mailbox_args[4] : 'UTF-8'
+        );
+    }
+}

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -14,7 +14,6 @@ use function date;
 use Exception;
 use Generator;
 use ParagonIE\HiddenString\HiddenString;
-use PHPUnit\Framework\TestCase;
 use const TYPETEXT;
 
 /**
@@ -39,7 +38,7 @@ use const TYPETEXT;
  *
  * @todo see @todo of Imap::mail_compose()
  */
-class LiveMailboxTest extends TestCase
+class LiveMailboxTest extends AbstractLiveMailboxTest
 {
     const RANDOM_MAILBOX_SAMPLE_SIZE = 3;
 
@@ -47,26 +46,6 @@ class LiveMailboxTest extends TestCase
         448 => 1,
         391 => 2,
     ];
-
-    /**
-     * Provides constructor arguments for a live mailbox.
-     *
-     * @psalm-return MAILBOX_ARGS[]
-     */
-    public function MailBoxProvider(): array
-    {
-        $sets = [];
-
-        $imapPath = \getenv('PHPIMAP_IMAP_PATH');
-        $login = \getenv('PHPIMAP_LOGIN');
-        $password = \getenv('PHPIMAP_PASSWORD');
-
-        if (\is_string($imapPath) && \is_string($login) && \is_string($password)) {
-            $sets['CI ENV'] = [new HiddenString($imapPath), new HiddenString($login), new HiddenString($password, true, true), \sys_get_temp_dir()];
-        }
-
-        return $sets;
-    }
 
     /**
      * @dataProvider MailBoxProvider
@@ -764,49 +743,6 @@ class LiveMailboxTest extends TestCase
                 'If a subject was found,'.
                 ' then the message is was not expunged as requested.'
             )
-        );
-    }
-
-    /**
-     * Get instance of Mailbox, pre-set to a random mailbox.
-     *
-     * @param string $attachmentsDir
-     * @param string $serverEncoding
-     *
-     * @return mixed[]
-     *
-     * @psalm-return array{0:Mailbox, 1:string, 2:HiddenString}
-     */
-    protected function getMailbox(HiddenString $imapPath, HiddenString $login, HiddenString $password, $attachmentsDir, $serverEncoding = 'UTF-8')
-    {
-        $mailbox = new Mailbox($imapPath->getString(), $login->getString(), $password->getString(), $attachmentsDir, $serverEncoding);
-
-        $random = 'test-box-'.\date('c').\bin2hex(\random_bytes(4));
-
-        $mailbox->createMailbox($random);
-
-        $mailbox->switchMailbox($random, false);
-
-        return [$mailbox, $random, $imapPath];
-    }
-
-    /**
-     * @psalm-param MAILBOX_ARGS $mailbox_args
-     *
-     * @return mixed[]
-     *
-     * @psalm-return array{0:Mailbox, 1:string, 2:HiddenString}
-     */
-    protected function getMailboxFromArgs(array $mailbox_args): array
-    {
-        list($path, $username, $password, $attachments_dir) = $mailbox_args;
-
-        return $this->getMailbox(
-            $path,
-            $username,
-            $password,
-            $attachments_dir,
-            isset($mailbox_args[4]) ? $mailbox_args[4] : 'UTF-8'
         );
     }
 

--- a/tests/unit/LiveMailboxWithManualSetupTest.php
+++ b/tests/unit/LiveMailboxWithManualSetupTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Live Mailbox - PHPUnit tests.
+ *
+ * Runs tests on a live mailbox
+ *
+ * @author BAPCLTD-Marv
+ */
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use Generator;
+use ParagonIE\HiddenString\HiddenString;
+
+/**
+ * @psalm-type MAILBOX_ARGS = array{
+ *	0:HiddenString,
+ *	1:HiddenString,
+ *	2:HiddenString,
+ *	3:string,
+ *	4?:string
+ * }
+ */
+class LiveMailboxWithManualSetupTest extends AbstractLiveMailboxTest
+{
+    /**
+     * @return Generator<int, array{0:string}, void, void>
+     */
+    public function RelativeToRootPathProvider(): Generator
+    {
+        yield [
+            '.issue-499.Éléments envoyés',
+        ];
+    }
+
+    /**
+     * @return Generator<int, array{0:MAILBOX_ARGS}, void, void>
+     */
+    public function statusProviderAbsolutePath(): Generator
+    {
+        foreach ($this->RelativeToRootPathProvider() as $path_args) {
+            foreach ($this->MailBoxProvider() as $args) {
+                $args[0] = new HiddenString($args[0]->getString().$path_args[0]);
+
+                yield [$args];
+            }
+        }
+    }
+
+    /**
+     * Tests the status of an absolute mailbox path set from the Mailbox constructor.
+     *
+     * @dataProvider statusProviderAbsolutePath
+     *
+     * @group live-manual
+     *
+     * @psalm-param MAILBOX_ARGS $mailbox_args
+     */
+    public function testAbsolutePathStatusFromConstruction(
+        array $mailbox_args
+    ): void {
+        list($mailbox) = $this->getMailboxFromArgs($mailbox_args);
+
+        $mailbox->statusMailbox();
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -387,6 +387,7 @@ final class MailboxTest extends TestCase
             'Deutsch' => ['Deutsch'], // German
             'U.S. English' => ['U.S. English'], // U.S. English
             'français' => ['français'], // French
+            'Éléments envoyés' => ['Éléments envoyés'], // issue 499
             'føroyskt' => ['føroyskt'], // Faroese
             'Kĩmĩrũ' => ['Kĩmĩrũ'], // Kimîîru
             'Kɨlaangi' => ['Kɨlaangi'], // Langi


### PR DESCRIPTION
* bd7dfce [fails](https://travis-ci.org/github/bapcltd/php-imap/builds/685333307) as reported in #499 
* ef4a5ab [passes](https://travis-ci.org/github/bapcltd/php-imap/builds/685335052) with the patch suggested by jeanphiB

note this PR introduces a live mailbox test that requires manual setup- in this case, a `Éléments envoyés` folder inside a  `issue-499` folder.