### PR TITLE
fixes #501

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.3
 
 env:
-  - phpunitflags="--stop-on-failure --testdox --exclude-group=live,live-manual"
+  - phpunitflags="--stop-on-failure --testdox --exclude-group=live"
 
 matrix:
   fast_finish: true

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1241,10 +1241,6 @@ class Mailbox
      */
     public function decodeMimeStr(string $string): string
     {
-        if (empty(\trim($string))) {
-            throw new Exception('decodeMimeStr() Can not decode an empty string!');
-        }
-
         $newString = '';
         /** @var list<object{charset?:string, text?:string}>|false */
         $elements = \imap_mime_header_decode($string);

--- a/tests/unit/AbstractLiveMailboxTest.php
+++ b/tests/unit/AbstractLiveMailboxTest.php
@@ -86,4 +86,24 @@ abstract class AbstractLiveMailboxTest extends TestCase
             isset($mailbox_args[4]) ? $mailbox_args[4] : 'UTF-8'
         );
     }
+
+    /**
+     * Get subject search criteria and subject.
+     *
+     * @psalm-param array{subject?:mixed} $envelope
+     *
+     * @psalm-return array{0:string, 1:string}
+     */
+    protected function SubjectSearchCriteriaAndSubject(array $envelope): array
+    {
+        /** @var string|null */
+        $subject = isset($envelope['subject']) ? $envelope['subject'] : null;
+
+        $this->assertIsString($subject);
+
+        $search_criteria = \sprintf('SUBJECT "%s"', (string) $subject);
+
+        /** @psalm-var array{0:string, 1:string} */
+        return [$search_criteria, (string) $subject];
+    }
 }

--- a/tests/unit/LiveMailboxIssue501Test.php
+++ b/tests/unit/LiveMailboxIssue501Test.php
@@ -26,6 +26,27 @@ use const TYPETEXT;
 class LiveMailboxIssue501Test extends AbstractLiveMailboxTest
 {
     /**
+     * @group offline
+     * @group offline-issue-501
+     */
+    public function testDecodeMimeStrEmpty(): void
+    {
+        $this->assertSame([], \imap_mime_header_decode(''));
+
+        // example credentials nabbed from MailboxTest::testConstructorTrimsPossibleVariables()
+        $imapPath = ' {imap.example.com:993/imap/ssl}INBOX     ';
+        $login = '    php-imap@example.com';
+        $password = '  v3rY!53cEt&P4sSWöRd$';
+        // directory names can contain spaces before AND after on Linux/Unix systems. Windows trims these spaces automatically.
+        $attachmentsDir = '.';
+        $serverEncoding = 'UTF-8  ';
+
+        $mailbox = new Mailbox($imapPath, $login, $password, $attachmentsDir, $serverEncoding);
+
+        $this->assertSame('', $mailbox->decodeMimeStr(''));
+    }
+
+    /**
      * @dataProvider MailBoxProvider
      *
      * @group live

--- a/tests/unit/LiveMailboxIssue501Test.php
+++ b/tests/unit/LiveMailboxIssue501Test.php
@@ -28,6 +28,7 @@ class LiveMailboxIssue501Test extends AbstractLiveMailboxTest
     /**
      * @dataProvider MailBoxProvider
      *
+     * @group live
      * @group live-issue-501
      */
     public function testGetEmptyBody(

--- a/tests/unit/LiveMailboxIssue501Test.php
+++ b/tests/unit/LiveMailboxIssue501Test.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Live Mailbox - PHPUnit tests.
+ *
+ * Runs tests on a live mailbox
+ *
+ * @author BAPCLTD-Marv
+ */
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use Exception;
+use ParagonIE\HiddenString\HiddenString;
+use const TYPETEXT;
+
+/**
+ * @psalm-type MAILBOX_ARGS = array{
+ *	0:HiddenString,
+ *	1:HiddenString,
+ *	2:HiddenString,
+ *	3:string,
+ *	4?:string
+ * }
+ */
+class LiveMailboxIssue501Test extends AbstractLiveMailboxTest
+{
+    /**
+     * @dataProvider MailBoxProvider
+     *
+     * @group live-issue-501
+     */
+    public function testGetEmptyBody(
+        HiddenString $imapPath,
+        HiddenString $login,
+        HiddenString $password,
+        string $attachmentsDir,
+        string $serverEncoding = 'UTF-8'
+    ): void {
+        list($mailbox, $remove_mailbox) = $this->getMailbox(
+            $imapPath,
+            $login,
+            $password,
+            $attachmentsDir,
+            $serverEncoding
+        );
+
+        $exception = null;
+
+        try {
+            $envelope = [
+                'subject' => 'barbushin/php-imap#501: '.\bin2hex(\random_bytes(16)),
+            ];
+
+            list($search_criteria) = $this->SubjectSearchCriteriaAndSubject(
+                $envelope
+            );
+
+            $search = $mailbox->searchMailbox($search_criteria);
+
+            $this->assertCount(
+                0,
+                $search,
+                (
+                    'If a subject was found,'.
+                    ' then the message is insufficiently unique to assert that'.
+                    ' a newly-appended message was actually created.'
+                )
+            );
+
+            $mailbox->appendMessageToMailbox(Imap::mail_compose(
+                $envelope,
+                [
+                    [
+                        'type' => TYPETEXT,
+                        'contents.data' => '',
+                    ],
+                ]
+            ));
+
+            $search = $mailbox->searchMailbox($search_criteria);
+
+            $this->assertCount(
+                1,
+                $search,
+                (
+                    'If a subject was not found, '.
+                    ' then Mailbox::appendMessageToMailbox() failed'.
+                    ' despite not throwing an exception.'
+                )
+            );
+
+            $mail = $mailbox->getMail($search[0], false);
+
+            $this->assertSame('', $mail->textPlain);
+        } catch (Exception $ex) {
+            $exception = $ex;
+        } finally {
+            $mailbox->switchMailbox($imapPath->getString());
+            $mailbox->deleteMailbox($remove_mailbox);
+            $mailbox->disconnect();
+        }
+
+        if (null !== $exception) {
+            throw $exception;
+        }
+    }
+}

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -760,26 +760,6 @@ class LiveMailboxTest extends AbstractLiveMailboxTest
     }
 
     /**
-     * Get subject search criteria and subject.
-     *
-     * @psalm-param array{subject?:mixed} $envelope
-     *
-     * @psalm-return array{0:string, 1:string}
-     */
-    protected function SubjectSearchCriteriaAndSubject(array $envelope): array
-    {
-        /** @var string|null */
-        $subject = isset($envelope['subject']) ? $envelope['subject'] : null;
-
-        $this->assertIsString($subject);
-
-        $search_criteria = \sprintf('SUBJECT "%s"', (string) $subject);
-
-        /** @psalm-var array{0:string, 1:string} */
-        return [$search_criteria, (string) $subject];
-    }
-
-    /**
      * @param string $expected_result
      * @param string $actual_result
      *

--- a/tests/unit/LiveMailboxWithManualSetupTest.php
+++ b/tests/unit/LiveMailboxWithManualSetupTest.php
@@ -53,6 +53,7 @@ class LiveMailboxWithManualSetupTest extends AbstractLiveMailboxTest
      *
      * @dataProvider statusProviderAbsolutePath
      *
+     * @group live
      * @group live-manual
      *
      * @psalm-param MAILBOX_ARGS $mailbox_args

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -523,7 +523,7 @@ final class MailboxTest extends TestCase
             ['=?iso-8859-1?Q?Sebastian_Kr=E4tzig?=', 'Sebastian Krätzig'],
             ['sebastian.kraetzig', 'sebastian.kraetzig'],
             ['=?US-ASCII?Q?Keith_Moore?= <km@ab.example.edu>', 'Keith Moore <km@ab.example.edu>'],
-            ['   ', ''],
+            ['   ', '   '],
             ['=?ISO-8859-1?Q?Max_J=F8rn_Simsen?= <max.joern.s@example.dk>', 'Max Jørn Simsen <max.joern.s@example.dk>'],
             ['=?ISO-8859-1?Q?Andr=E9?= Muster <andre.muster@vm1.ulg.ac.be>', 'André Muster <andre.muster@vm1.ulg.ac.be>'],
             ['=?ISO-8859-1?B?SWYgeW91IGNhbiByZWFkIHRoaXMgeW8=?= =?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=', 'If you can read this you understand the example.'],
@@ -539,12 +539,7 @@ final class MailboxTest extends TestCase
     {
         $mailbox = $this->getMailbox();
 
-        if (empty($expected)) {
-            $this->expectException(Exception::class);
-            $mailbox->decodeMimeStr($str);
-        } else {
             $this->assertEquals($mailbox->decodeMimeStr($str), $expected);
-        }
     }
 
     /**

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -527,6 +527,7 @@ final class MailboxTest extends TestCase
             ['=?ISO-8859-1?Q?Max_J=F8rn_Simsen?= <max.joern.s@example.dk>', 'Max Jørn Simsen <max.joern.s@example.dk>'],
             ['=?ISO-8859-1?Q?Andr=E9?= Muster <andre.muster@vm1.ulg.ac.be>', 'André Muster <andre.muster@vm1.ulg.ac.be>'],
             ['=?ISO-8859-1?B?SWYgeW91IGNhbiByZWFkIHRoaXMgeW8=?= =?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=', 'If you can read this you understand the example.'],
+            ['', ''], // barbushin/php-imap#501
         ];
     }
 

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -540,7 +540,7 @@ final class MailboxTest extends TestCase
     {
         $mailbox = $this->getMailbox();
 
-            $this->assertEquals($mailbox->decodeMimeStr($str), $expected);
+        $this->assertEquals($mailbox->decodeMimeStr($str), $expected);
     }
 
     /**

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace PhpImap;
 
 use DateTime;
-use Exception;
 use PhpImap\Exceptions\InvalidParameterException;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
* fixes #501
* uses multiple groups on test methods rather than multiple entries on travis `phpunitflags`