### PR TITLE
avoid adding plain text attachments to `IncomingMail::$dataInfo`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,17 @@
         "vimeo/psalm": "^3.11"
     },
     "scripts": {
-        "tests": [
+        "static-analysis": [
             "parallel-lint .php_cs.dist src tests examples",
             "phpcpd src tests",
-            "phpunit --testdox",
             "composer-require-checker check ./composer.json",
             "phpmnd ./ --exclude=./.github/ --exclude=./examples/ --exclude=./vendor/ --non-zero-exit-on-violation --hint",
             "php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run --diff-format=udiff -v",
             "psalm --show-info=false"
+        ],
+        "tests": [
+            "@static-analysis",
+            "phpunit --testdox"
         ]
     },
     "suggest": {

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1532,8 +1532,18 @@ class Mailbox
 
         $isAttachment = isset($params['filename']) || isset($params['name']);
 
+        $dispositionAttachment = (
+            isset($partStructure->disposition) &&
+            \is_string($partStructure->disposition) &&
+            'attachment' === \mb_strtolower($partStructure->disposition)
+        );
+
         // ignore contentId on body when mail isn't multipart (https://github.com/barbushin/php-imap/issues/71)
-        if (!$partNum && TYPETEXT === $partStructure->type) {
+        if (
+            !$partNum &&
+            TYPETEXT === $partStructure->type &&
+            !$dispositionAttachment
+        ) {
             $isAttachment = false;
         }
 
@@ -1590,12 +1600,16 @@ class Mailbox
         } else {
             if (TYPETEXT === $partStructure->type) {
                 if ('plain' === \mb_strtolower($partStructure->subtype)) {
+                    if ($dispositionAttachment) {
+                        return;
+                    }
+
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_PLAIN);
                 } elseif (!$partStructure->ifdisposition) {
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_HTML);
                 } elseif (!\is_string($partStructure->disposition)) {
                     throw new InvalidArgumentException('disposition property of object passed as argument 2 to '.__METHOD__.'() was present but not a string!');
-                } elseif ('attachment' !== \mb_strtolower($partStructure->disposition)) {
+                } elseif (!$dispositionAttachment) {
                     $mail->addDataPartInfo($dataInfo, DataPartInfo::TEXT_HTML);
                 }
             } elseif (TYPEMESSAGE === $partStructure->type) {

--- a/tests/unit/LiveMailboxIssue490Test.php
+++ b/tests/unit/LiveMailboxIssue490Test.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Live Mailbox - PHPUnit tests.
+ *
+ * Runs tests on a live mailbox
+ *
+ * @author BAPCLTD-Marv
+ */
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use Exception;
+use ParagonIE\HiddenString\HiddenString;
+use const TYPETEXT;
+
+/**
+ * @psalm-type MAILBOX_ARGS = array{
+ *	0:HiddenString,
+ *	1:HiddenString,
+ *	2:HiddenString,
+ *	3:string,
+ *	4?:string
+ * }
+ */
+class LiveMailboxIssue490Test extends AbstractLiveMailboxTest
+{
+    /**
+     * @dataProvider MailBoxProvider
+     *
+     * @group live
+     * @group live-issue-490
+     */
+    public function testGetTextAttachments(
+        HiddenString $imapPath,
+        HiddenString $login,
+        HiddenString $password,
+        string $attachmentsDir,
+        string $serverEncoding = 'UTF-8'
+    ): void {
+        list($mailbox, $remove_mailbox) = $this->getMailbox(
+            $imapPath,
+            $login,
+            $password,
+            $attachmentsDir,
+            $serverEncoding
+        );
+
+        $exception = null;
+
+        try {
+            $envelope = [
+                'subject' => 'barbushin/php-imap#501: '.\bin2hex(\random_bytes(16)),
+            ];
+
+            list($search_criteria) = $this->SubjectSearchCriteriaAndSubject(
+                $envelope
+            );
+
+            $search = $mailbox->searchMailbox($search_criteria);
+
+            $this->assertCount(
+                0,
+                $search,
+                (
+                    'If a subject was found,'.
+                    ' then the message is insufficiently unique to assert that'.
+                    ' a newly-appended message was actually created.'
+                )
+            );
+
+            $message = Imap::mail_compose(
+                $envelope,
+                [
+                    [
+                        'type' => TYPEMULTIPART,
+                    ],
+                    [
+                        'type' => TYPETEXT,
+                        'contents.data' => 'foo',
+                    ],
+                    [
+                        'type' => TYPEMULTIPART,
+                        'subtype' => 'plain',
+                        'description' => 'bar.txt',
+                        'disposition.type' => 'attachment',
+                        'disposition' => ['filename' => 'bar.txt'],
+                        'type.parameters' => ['name' => 'bar.txt'],
+                        'contents.data' => 'bar',
+                    ],
+                    [
+                        'type' => TYPEMULTIPART,
+                        'subtype' => 'plain',
+                        'description' => 'baz.txt',
+                        'disposition.type' => 'attachment',
+                        'disposition' => ['filename' => 'baz.txt'],
+                        'type.parameters' => ['name' => 'baz.txt'],
+                        'contents.data' => 'baz',
+                    ],
+                ]
+            );
+
+            $mailbox->appendMessageToMailbox($message);
+
+            $search = $mailbox->searchMailbox($search_criteria);
+
+            $this->assertCount(
+                1,
+                $search,
+                (
+                    'If a subject was not found, '.
+                    ' then Mailbox::appendMessageToMailbox() failed'.
+                    ' despite not throwing an exception.'
+                )
+            );
+
+            $mail = $mailbox->getMail($search[0], false);
+
+            $this->assertSame('foo', $mail->textPlain);
+
+            $attachments = $mail->getAttachments();
+            $keys = \array_keys($attachments);
+
+            $this->assertCount(2, $attachments);
+
+            $this->assertSame('bar', $attachments[$keys[0]]->getContents());
+            $this->assertSame('baz', $attachments[$keys[1]]->getContents());
+        } catch (Exception $ex) {
+            $exception = $ex;
+        } finally {
+            $mailbox->switchMailbox($imapPath->getString());
+            $mailbox->deleteMailbox($remove_mailbox);
+            $mailbox->disconnect();
+        }
+
+        if (null !== $exception) {
+            throw $exception;
+        }
+    }
+}


### PR DESCRIPTION
* ~`a852f76 and ed8a361 are cherry-picked from #502`~ rebased
* ~1f7ca2b~ bd79ccf makes running static analysis a separate command, which is handy when developing live mailbox tests for just one issue.
* ~4070523~ f54808e implements tests which [replicate the issue, failing as expected](https://travis-ci.org/github/bapcltd/php-imap/builds/687073606)
* ~d5bea081~ 2ff6116 implements the fix which [~should succeed~ succeeds on travis as it does locally](https://travis-ci.org/github/bapcltd/php-imap/builds/687477715)