### PR TITLE
Disable utf7 imap encoding of search criteria by default

### DIFF
--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -821,7 +821,7 @@ final class Imap
         $imap_stream = static::EnsureConnection($imap_stream, __METHOD__, 1);
 
         if ($encodeCriteriaAsUtf7Imap) {
-        $criteria = static::encodeStringToUtf7Imap($criteria);
+            $criteria = static::encodeStringToUtf7Imap($criteria);
         }
 
         if (\is_string($charset)) {

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -813,12 +813,16 @@ final class Imap
         $imap_stream,
         string $criteria,
         int $options = SE_FREE,
-        string $charset = null
+        string $charset = null,
+        bool $encodeCriteriaAsUtf7Imap = true
     ): array {
         \imap_errors(); // flush errors
 
         $imap_stream = static::EnsureConnection($imap_stream, __METHOD__, 1);
+
+        if ($encodeCriteriaAsUtf7Imap) {
         $criteria = static::encodeStringToUtf7Imap($criteria);
+        }
 
         if (\is_string($charset)) {
             $result = \imap_search(

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -814,7 +814,7 @@ final class Imap
         string $criteria,
         int $options = SE_FREE,
         string $charset = null,
-        bool $encodeCriteriaAsUtf7Imap = true
+        bool $encodeCriteriaAsUtf7Imap = false
     ): array {
         \imap_errors(); // flush errors
 

--- a/tests/unit/AbstractLiveMailboxTest.php
+++ b/tests/unit/AbstractLiveMailboxTest.php
@@ -179,7 +179,7 @@ abstract class AbstractLiveMailboxTest extends TestCase
         } finally {
             $mailbox->switchMailbox($path->getString());
             if (!$mailboxDeleted) {
-            $mailbox->deleteMailbox($remove_mailbox);
+                $mailbox->deleteMailbox($remove_mailbox);
             }
             $mailbox->disconnect();
         }

--- a/tests/unit/AbstractLiveMailboxTest.php
+++ b/tests/unit/AbstractLiveMailboxTest.php
@@ -13,6 +13,7 @@ namespace PhpImap;
 use Generator;
 use ParagonIE\HiddenString\HiddenString;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 /**
  * @psalm-type MAILBOX_ARGS = array{
@@ -119,6 +120,10 @@ abstract class AbstractLiveMailboxTest extends TestCase
             $mailbox_args
         );
 
+        /** @var Throwable|null */
+        $exception = null;
+
+        try {
         $search = $mailbox->searchMailbox($search_criteria);
 
         $this->assertCount(
@@ -166,6 +171,17 @@ abstract class AbstractLiveMailboxTest extends TestCase
                 ' then the message is was not expunged as requested.'
             )
         );
+        } catch (Throwable $ex) {
+            $exception = $ex;
+        } finally {
+            $mailbox->switchMailbox($path->getString());
+            $mailbox->deleteMailbox($remove_mailbox);
+            $mailbox->disconnect();
+        }
+
+        if (null !== $exception) {
+            throw $exception;
+        }
     }
 
     /**

--- a/tests/unit/AbstractLiveMailboxTest.php
+++ b/tests/unit/AbstractLiveMailboxTest.php
@@ -124,53 +124,53 @@ abstract class AbstractLiveMailboxTest extends TestCase
         $exception = null;
 
         try {
-        $search = $mailbox->searchMailbox($search_criteria);
+            $search = $mailbox->searchMailbox($search_criteria);
 
-        $this->assertCount(
-            0,
-            $search,
-            (
-                'If a subject was found,'.
-                ' then the message is insufficiently unique to assert that'.
-                ' a newly-appended message was actually created.'
-            )
-        );
+            $this->assertCount(
+                0,
+                $search,
+                (
+                    'If a subject was found,'.
+                    ' then the message is insufficiently unique to assert that'.
+                    ' a newly-appended message was actually created.'
+                )
+            );
 
-        $message = [$envelope, $body];
+            $message = [$envelope, $body];
 
-        if ($pre_compose) {
-            $message = Imap::mail_compose($envelope, $body);
-        }
+            if ($pre_compose) {
+                $message = Imap::mail_compose($envelope, $body);
+            }
 
-        $mailbox->appendMessageToMailbox($message);
+            $mailbox->appendMessageToMailbox($message);
 
-        $search = $mailbox->searchMailbox($search_criteria);
+            $search = $mailbox->searchMailbox($search_criteria);
 
-        $this->assertCount(
-            1,
-            $search,
-            (
-                'If a subject was not found, '.
-                ' then Mailbox::appendMessageToMailbox() failed'.
-                ' despite not throwing an exception.'
-            )
-        );
+            $this->assertCount(
+                1,
+                $search,
+                (
+                    'If a subject was not found, '.
+                    ' then Mailbox::appendMessageToMailbox() failed'.
+                    ' despite not throwing an exception.'
+                )
+            );
 
-        $mailbox->deleteMail($search[0]);
+            $mailbox->deleteMail($search[0]);
 
-        $mailbox->expungeDeletedMails();
+            $mailbox->expungeDeletedMails();
 
-        $mailbox->switchMailbox($path->getString());
-        $mailbox->deleteMailbox($remove_mailbox);
+            $mailbox->switchMailbox($path->getString());
+            $mailbox->deleteMailbox($remove_mailbox);
 
-        $this->assertCount(
-            0,
-            $mailbox->searchMailbox($search_criteria),
-            (
-                'If a subject was found,'.
-                ' then the message is was not expunged as requested.'
-            )
-        );
+            $this->assertCount(
+                0,
+                $mailbox->searchMailbox($search_criteria),
+                (
+                    'If a subject was found,'.
+                    ' then the message is was not expunged as requested.'
+                )
+            );
         } catch (Throwable $ex) {
             $exception = $ex;
         } finally {

--- a/tests/unit/AbstractLiveMailboxTest.php
+++ b/tests/unit/AbstractLiveMailboxTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace PhpImap;
 
+use Generator;
 use ParagonIE\HiddenString\HiddenString;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +22,17 @@ use PHPUnit\Framework\TestCase;
  *	3:string,
  *	4?:string
  * }
+ * @psalm-type COMPOSE_ENVELOPE = array{
+ *	subject?:string
+ * }
+ * @psalm-type COMPOSE_BODY = list<array{
+ *	type?:int,
+ *	encoding?:int,
+ *	charset?:string,
+ *	subtype?:string,
+ *	description?:string,
+ *	disposition?:array{filename:string}
+ * }>
  */
 abstract class AbstractLiveMailboxTest extends TestCase
 {
@@ -42,6 +54,118 @@ abstract class AbstractLiveMailboxTest extends TestCase
         }
 
         return $sets;
+    }
+
+    /**
+     * @psalm-return Generator<int, array{0:COMPOSE_ENVELOPE, 1:COMPOSE_BODY, 2:string}, mixed, void>
+     */
+    public function ComposeProvider(): Generator
+    {
+        yield from [];
+    }
+
+    /**
+     * @psalm-return Generator<int, array{
+     *	0:MAILBOX_ARGS,
+     *	1:COMPOSE_ENVELOPE,
+     *	2:COMPOSE_BODY,
+     *	3:string,
+     *	4:bool
+     * }, mixed, void>
+     */
+    public function AppendProvider(): Generator
+    {
+        foreach ($this->MailBoxProvider() as $mailbox_args) {
+            foreach ($this->ComposeProvider() as $compose_args) {
+                [$envelope, $body, $expected_compose_result] = $compose_args;
+
+                yield [$mailbox_args, $envelope, $body, $expected_compose_result, false];
+            }
+
+            foreach ($this->ComposeProvider() as $compose_args) {
+                [$envelope, $body, $expected_compose_result] = $compose_args;
+
+                yield [$mailbox_args, $envelope, $body, $expected_compose_result, true];
+            }
+        }
+    }
+
+    /**
+     * @dataProvider AppendProvider
+     *
+     * @group live
+     *
+     * @depends testGetImapStream
+     * @depends testMailCompose
+     *
+     * @psalm-param MAILBOX_ARGS $mailbox_args
+     * @psalm-param COMPOSE_ENVELOPE $envelope
+     * @psalm-param COMPOSE_BODY $body
+     */
+    public function testAppend(
+        array $mailbox_args,
+        array $envelope,
+        array $body,
+        string $_expected_compose_result,
+        bool $pre_compose
+    ): void {
+        if ($this->MaybeSkipAppendTest($envelope)) {
+            return;
+        }
+
+        list($search_criteria) = $this->SubjectSearchCriteriaAndSubject($envelope);
+
+        list($mailbox, $remove_mailbox, $path) = $this->getMailboxFromArgs(
+            $mailbox_args
+        );
+
+        $search = $mailbox->searchMailbox($search_criteria);
+
+        $this->assertCount(
+            0,
+            $search,
+            (
+                'If a subject was found,'.
+                ' then the message is insufficiently unique to assert that'.
+                ' a newly-appended message was actually created.'
+            )
+        );
+
+        $message = [$envelope, $body];
+
+        if ($pre_compose) {
+            $message = Imap::mail_compose($envelope, $body);
+        }
+
+        $mailbox->appendMessageToMailbox($message);
+
+        $search = $mailbox->searchMailbox($search_criteria);
+
+        $this->assertCount(
+            1,
+            $search,
+            (
+                'If a subject was not found, '.
+                ' then Mailbox::appendMessageToMailbox() failed'.
+                ' despite not throwing an exception.'
+            )
+        );
+
+        $mailbox->deleteMail($search[0]);
+
+        $mailbox->expungeDeletedMails();
+
+        $mailbox->switchMailbox($path->getString());
+        $mailbox->deleteMailbox($remove_mailbox);
+
+        $this->assertCount(
+            0,
+            $mailbox->searchMailbox($search_criteria),
+            (
+                'If a subject was found,'.
+                ' then the message is was not expunged as requested.'
+            )
+        );
     }
 
     /**
@@ -105,5 +229,18 @@ abstract class AbstractLiveMailboxTest extends TestCase
 
         /** @psalm-var array{0:string, 1:string} */
         return [$search_criteria, (string) $subject];
+    }
+
+    protected function MaybeSkipAppendTest(array $envelope): bool
+    {
+        if (!isset($envelope['subject'])) {
+            $this->markTestSkipped(
+                'Cannot search for message by subject, no subject specified!'
+            );
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/unit/AbstractLiveMailboxTest.php
+++ b/tests/unit/AbstractLiveMailboxTest.php
@@ -123,6 +123,8 @@ abstract class AbstractLiveMailboxTest extends TestCase
         /** @var Throwable|null */
         $exception = null;
 
+        $mailboxDeleted = false;
+
         try {
             $search = $mailbox->searchMailbox($search_criteria);
 
@@ -162,6 +164,7 @@ abstract class AbstractLiveMailboxTest extends TestCase
 
             $mailbox->switchMailbox($path->getString());
             $mailbox->deleteMailbox($remove_mailbox);
+            $mailboxDeleted = true;
 
             $this->assertCount(
                 0,
@@ -175,7 +178,9 @@ abstract class AbstractLiveMailboxTest extends TestCase
             $exception = $ex;
         } finally {
             $mailbox->switchMailbox($path->getString());
+            if (!$mailboxDeleted) {
             $mailbox->deleteMailbox($remove_mailbox);
+            }
             $mailbox->disconnect();
         }
 

--- a/tests/unit/LiveMailboxIssue250Test.php
+++ b/tests/unit/LiveMailboxIssue250Test.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Live Mailbox - PHPUnit tests.
+ *
+ * Runs tests on a live mailbox
+ *
+ * @author BAPCLTD-Marv
+ */
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use Generator;
+use const TYPETEXT;
+
+/**
+ * @psalm-type COMPOSE_ENVELOPE = array{
+ *	subject?:string
+ * }
+ * @psalm-type COMPOSE_BODY = list<array{
+ *	type?:int,
+ *	encoding?:int,
+ *	charset?:string,
+ *	subtype?:string,
+ *	description?:string,
+ *	disposition?:array{filename:string}
+ * }>
+ */
+class LiveMailboxIssue250Test extends AbstractLiveMailboxTest
+{
+    /**
+     * @psalm-return Generator<int, array{0:COMPOSE_ENVELOPE, 1:COMPOSE_BODY, 2:string}, mixed, void>
+     */
+    public function ComposeProvider(): Generator
+    {
+        $random_subject = 'barbushin/php-imap#250 测试: '.\bin2hex(\random_bytes(16));
+
+        yield [
+            ['subject' => $random_subject],
+            [
+                [
+                    'type' => TYPETEXT,
+                    'contents.data' => 'test',
+                ],
+            ],
+            (
+                'Subject: '.$random_subject."\r\n".
+                'MIME-Version: 1.0'."\r\n".
+                'Content-Type: TEXT/PLAIN; CHARSET=US-ASCII'."\r\n".
+                "\r\n".
+                'test'."\r\n"
+            ),
+        ];
+    }
+}

--- a/tests/unit/LiveMailboxIssue250Test.php
+++ b/tests/unit/LiveMailboxIssue250Test.php
@@ -11,9 +11,17 @@ declare(strict_types=1);
 namespace PhpImap;
 
 use Generator;
+use ParagonIE\HiddenString\HiddenString;
 use const TYPETEXT;
 
 /**
+ * @psalm-type MAILBOX_ARGS = array{
+ *	0:HiddenString,
+ *	1:HiddenString,
+ *	2:HiddenString,
+ *	3:string,
+ *	4?:string
+ * }
  * @psalm-type COMPOSE_ENVELOPE = array{
  *	subject?:string
  * }
@@ -51,5 +59,31 @@ class LiveMailboxIssue250Test extends AbstractLiveMailboxTest
                 'test'."\r\n"
             ),
         ];
+    }
+
+    /**
+     * @dataProvider AppendProvider
+     *
+     * @group live
+     * @group live-issue-250
+     *
+     * @psalm-param MAILBOX_ARGS $mailbox_args
+     * @psalm-param COMPOSE_ENVELOPE $envelope
+     * @psalm-param COMPOSE_BODY $body
+     */
+    public function testAppend(
+        array $mailbox_args,
+        array $envelope,
+        array $body,
+        string $expected_compose_result,
+        bool $pre_compose
+    ): void {
+        parent::testAppend(
+            $mailbox_args,
+            $envelope,
+            $body,
+            $expected_compose_result,
+            $pre_compose
+        );
     }
 }

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -12,10 +12,10 @@ namespace PhpImap;
 
 use function date;
 use const ENCBASE64;
-use Exception;
 use Generator;
 use ParagonIE\HiddenString\HiddenString;
 use const SORTARRIVAL;
+use Throwable;
 use const TYPEAPPLICATION;
 use const TYPEMULTIPART;
 use const TYPETEXT;
@@ -66,7 +66,7 @@ class LiveMailboxTest extends AbstractLiveMailboxTest
             $serverEncoding
         );
 
-        /** @var Exception|null */
+        /** @var Throwable|null */
         $exception = null;
 
         try {
@@ -129,7 +129,7 @@ class LiveMailboxTest extends AbstractLiveMailboxTest
 
                 $this->assertSame($check->Nmsgs, $mailbox->countMails(), 'Mailbox::checkMailbox()->Nmsgs did not match Mailbox::countMails()!');
             }
-        } catch (Exception $ex) {
+        } catch (Throwable $ex) {
             $exception = $ex;
         } finally {
             $mailbox->switchMailbox($imapPath->getString());

--- a/tests/unit/LiveMailboxTest.php
+++ b/tests/unit/LiveMailboxTest.php
@@ -315,110 +315,6 @@ class LiveMailboxTest extends AbstractLiveMailboxTest
     }
 
     /**
-     * @psalm-return Generator<int, array{
-     *	0:MAILBOX_ARGS,
-     *	1:COMPOSE_ENVELOPE,
-     *	2:COMPOSE_BODY,
-     *	3:string,
-     *	4:bool
-     * }, mixed, void>
-     */
-    public function AppendProvider(): Generator
-    {
-        foreach ($this->MailBoxProvider() as $mailbox_args) {
-            foreach ($this->ComposeProvider() as $compose_args) {
-                [$envelope, $body, $expected_compose_result] = $compose_args;
-
-                yield [$mailbox_args, $envelope, $body, $expected_compose_result, false];
-            }
-
-            foreach ($this->ComposeProvider() as $compose_args) {
-                [$envelope, $body, $expected_compose_result] = $compose_args;
-
-                yield [$mailbox_args, $envelope, $body, $expected_compose_result, true];
-            }
-        }
-    }
-
-    /**
-     * @dataProvider AppendProvider
-     *
-     * @group live
-     *
-     * @depends testGetImapStream
-     * @depends testMailCompose
-     *
-     * @psalm-param MAILBOX_ARGS $mailbox_args
-     * @psalm-param COMPOSE_ENVELOPE $envelope
-     * @psalm-param COMPOSE_BODY $body
-     */
-    public function testAppend(
-        array $mailbox_args,
-        array $envelope,
-        array $body,
-        string $_expected_compose_result,
-        bool $pre_compose
-    ): void {
-        if ($this->MaybeSkipAppendTest($envelope)) {
-            return;
-        }
-
-        list($search_criteria) = $this->SubjectSearchCriteriaAndSubject($envelope);
-
-        list($mailbox, $remove_mailbox, $path) = $this->getMailboxFromArgs(
-            $mailbox_args
-        );
-
-        $search = $mailbox->searchMailbox($search_criteria);
-
-        $this->assertCount(
-            0,
-            $search,
-            (
-                'If a subject was found,'.
-                ' then the message is insufficiently unique to assert that'.
-                ' a newly-appended message was actually created.'
-            )
-        );
-
-        $message = [$envelope, $body];
-
-        if ($pre_compose) {
-            $message = Imap::mail_compose($envelope, $body);
-        }
-
-        $mailbox->appendMessageToMailbox($message);
-
-        $search = $mailbox->searchMailbox($search_criteria);
-
-        $this->assertCount(
-            1,
-            $search,
-            (
-                'If a subject was not found, '.
-                ' then Mailbox::appendMessageToMailbox() failed'.
-                ' despite not throwing an exception.'
-            )
-        );
-
-        $mailbox->deleteMail($search[0]);
-
-        $mailbox->expungeDeletedMails();
-
-        $mailbox->switchMailbox($path->getString());
-        $mailbox->deleteMailbox($remove_mailbox);
-
-        $this->assertCount(
-            0,
-            $mailbox->searchMailbox($search_criteria),
-            (
-                'If a subject was found,'.
-                ' then the message is was not expunged as requested.'
-            )
-        );
-    }
-
-    /**
      * @dataProvider AppendProvider
      *
      * @group live
@@ -748,19 +644,6 @@ class LiveMailboxTest extends AbstractLiveMailboxTest
                 ' then the message is was not expunged as requested.'
             )
         );
-    }
-
-    protected function MaybeSkipAppendTest(array $envelope): bool
-    {
-        if (!isset($envelope['subject'])) {
-            $this->markTestSkipped(
-                'Cannot search for message by subject, no subject specified!'
-            );
-
-            return true;
-        }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
* this changeset adds a test for #250 
* this changeset "fixes" #250 by disabling utf7 imap encoding by default
* this changeset does not presently feature a way to enable encoding via `Mailbox` search methods, it's only available on `Imap::search()`

this fixes a bug by changing the default behaviour of the `Mailbox` & `Imap` classes- definitely something to mention in the changelog if accepted, but also wondering what the implications of the change are.

[the manual](https://www.php.net/manual/en/function.imap-utf7-encode.php) suggests utf7 imap encoding is only needed for *mailboxes*, so 🤷‍♂️?

draft pending #504