### PR TITLE
implementing bitmask validation of imap options, fixes #510

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ $mailbox = new PhpImap\Mailbox(
 	'UTF-8' // Server encoding (optional)
 );
 
+// set some connection arguments (if appropriate)
+$mailbox->setConnectionArgs(
+    CL_EXPUNGE // expunge deleted mails upon mailbox close
+    | OP_SECURE // don't do non-secure authentication
+);
+
 try {
 	// Get all emails (messages)
 	// PHP.net imap_search criteria: http://php.net/manual/en/function.imap-search.php

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -88,6 +88,18 @@ class Mailbox
 
     const PART_TYPE_TWO = 2;
 
+    const IMAP_OPTIONS_SUPPORTED_VALUES =
+        OP_READONLY // 2
+        | OP_ANONYMOUS // 4
+        | OP_HALFOPEN // 64
+        | CL_EXPUNGE // 32768
+        | OP_DEBUG // 1
+        | OP_SHORTCACHE // 8
+        | OP_SILENT // 16
+        | OP_PROTOTYPE // 32
+        | OP_SECURE // 256
+    ;
+
     /** @var string */
     public $decodeMimeStrDefaultCharset = 'default';
 
@@ -338,8 +350,7 @@ class Mailbox
     public function setConnectionArgs(int $options = 0, int $retriesNum = 0, array $params = null): void
     {
         if (0 !== $options) {
-            $supported_options = [OP_READONLY, OP_ANONYMOUS, OP_HALFOPEN, CL_EXPUNGE, OP_DEBUG, OP_SHORTCACHE, OP_SILENT, OP_PROTOTYPE, OP_SECURE];
-            if (!\in_array($options, $supported_options, true)) {
+            if (($options & self::IMAP_OPTIONS_SUPPORTED_VALUES) !== $options) {
                 throw new InvalidParameterException('Please check your option for setConnectionArgs()! Unsupported option "'.$options.'". Available options: https://www.php.net/manual/de/function.imap-open.php');
             }
             $this->imapOptions = $options;

--- a/tests/unit/Fixtures/Mailbox.php
+++ b/tests/unit/Fixtures/Mailbox.php
@@ -12,4 +12,9 @@ class Mailbox extends Base
     {
         return $this->imapPassword;
     }
+
+    public function getImapOptions(): int
+    {
+        return $this->imapOptions;
+    }
 }

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -755,8 +755,8 @@ final class MailboxTest extends TestCase
         $mailbox->setAttachmentsDir($attachmentsDir);
     }
 
-    protected function getMailbox(): Mailbox
+    protected function getMailbox(): Fixtures\Mailbox
     {
-        return new Mailbox($this->imapPath, $this->login, $this->password, $this->attachmentsDir, $this->serverEncoding);
+        return new Fixtures\Mailbox($this->imapPath, $this->login, $this->password, $this->attachmentsDir, $this->serverEncoding);
     }
 }

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -642,6 +642,7 @@ final class MailboxTest extends TestCase
         if ('expectException' == $assertMethod) {
             $this->expectException(InvalidParameterException::class);
             $mailbox->setConnectionArgs($option, $retriesNum, $param);
+            $this->assertSame($option, $mailbox->getImapOptions());
         } elseif ('assertNull' == $assertMethod) {
             $this->assertNull($mailbox->setConnectionArgs($option, $retriesNum, $param));
         }

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -605,40 +605,23 @@ final class MailboxTest extends TestCase
     public function connectionArgsProvider(): Generator
     {
         yield from [
-            'readonly, disable gssapi' =>
-            ['assertNull', OP_READONLY, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'anonymous, disable gssapi' =>
-            ['assertNull', OP_ANONYMOUS, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'half open, disable gssapi' =>
-            ['assertNull', OP_HALFOPEN, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'expunge on close, disable gssapi' =>
-            ['assertNull', CL_EXPUNGE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'debug, disable gssapi' =>
-            ['assertNull', OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'short cache, disable gssapi' =>
-            ['assertNull', OP_SHORTCACHE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'silent, disable gssapi' =>
-            ['assertNull', OP_SILENT, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'return driver prototype, disable gssapi' =>
-            ['assertNull', OP_PROTOTYPE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'don\'t do non-secure authentication, disable gssapi' =>
-            ['assertNull', OP_SECURE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly, disable gssapi, 1 retry' =>
-            ['assertNull', OP_READONLY, 1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly, disable gssapi, 3 retries' =>
-            ['assertNull', OP_READONLY, 3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly, disable gssapi, 12 retries' =>
-            ['assertNull', OP_READONLY, 12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly debug, disable gssapi' =>
-            ['expectException', OP_READONLY | OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly, -1 retries' =>
-            ['expectException', OP_READONLY, -1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly, -3 retries' =>
-            ['expectException', OP_READONLY, -3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly, -12 retries' =>
-            ['expectException', OP_READONLY, -12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly, null options' =>
-            ['expectException', OP_READONLY, 0, [null]],
+            'readonly, disable gssapi' => ['assertNull', OP_READONLY, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'anonymous, disable gssapi' => ['assertNull', OP_ANONYMOUS, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'half open, disable gssapi' => ['assertNull', OP_HALFOPEN, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'expunge on close, disable gssapi' => ['assertNull', CL_EXPUNGE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'debug, disable gssapi' => ['assertNull', OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'short cache, disable gssapi' => ['assertNull', OP_SHORTCACHE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'silent, disable gssapi' => ['assertNull', OP_SILENT, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'return driver prototype, disable gssapi' => ['assertNull', OP_PROTOTYPE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'don\'t do non-secure authentication, disable gssapi' => ['assertNull', OP_SECURE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, disable gssapi, 1 retry' => ['assertNull', OP_READONLY, 1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, disable gssapi, 3 retries' => ['assertNull', OP_READONLY, 3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, disable gssapi, 12 retries' => ['assertNull', OP_READONLY, 12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly debug, disable gssapi' => ['expectException', OP_READONLY | OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, -1 retries' => ['expectException', OP_READONLY, -1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, -3 retries' => ['expectException', OP_READONLY, -3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, -12 retries' => ['expectException', OP_READONLY, -12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, null options' => ['expectException', OP_READONLY, 0, [null]],
         ];
     }
 

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -617,7 +617,7 @@ final class MailboxTest extends TestCase
             'readonly, disable gssapi, 1 retry' => ['assertNull', OP_READONLY, 1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
             'readonly, disable gssapi, 3 retries' => ['assertNull', OP_READONLY, 3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
             'readonly, disable gssapi, 12 retries' => ['assertNull', OP_READONLY, 12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            'readonly debug, disable gssapi' => ['expectException', OP_READONLY | OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly debug, disable gssapi' => ['assertNull', OP_READONLY | OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
             'readonly, -1 retries' => ['expectException', OP_READONLY, -1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
             'readonly, -3 retries' => ['expectException', OP_READONLY, -3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
             'readonly, -12 retries' => ['expectException', OP_READONLY, -12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -623,6 +623,40 @@ final class MailboxTest extends TestCase
             'readonly, -12 retries' => ['expectException', OP_READONLY, -12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
             'readonly, null options' => ['expectException', OP_READONLY, 0, [null]],
         ];
+
+        /** @psalm-var list<array{0:int, 1:string}> */
+        $options = [
+            [OP_DEBUG, 'debug'], // 1
+            [OP_READONLY, 'readonly'], // 2
+            [OP_ANONYMOUS, 'anonymous'], // 4
+            [OP_SHORTCACHE, 'short cache'], // 8
+            [OP_SILENT, 'silent'], // 16
+            [OP_PROTOTYPE, 'return driver prototype'], // 32
+            [OP_HALFOPEN, 'half-open'], // 64
+            [OP_SECURE, 'don\'t do non-secure authnetication'], // 256
+            [CL_EXPUNGE, 'expunge on close'], // 32768
+        ];
+
+        foreach ($options as $i => $option) {
+            $value = $option[0];
+
+            for ($j = $i + 1; $j < \count($options); ++$j) {
+                $value |= $options[$j][0];
+
+                $fields = [];
+
+                foreach ($options as $option) {
+                    if (0 !== ($value & $option[0])) {
+                        $fields[] = $option[1];
+                    }
+                }
+
+                $key = \implode(', ', $fields);
+
+                yield $key => ['assertNull', $value, 0, []];
+                yield ('INVALID + '.$key) => ['expectException', $value | 128, 0, []];
+            }
+        }
     }
 
     /**

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -677,6 +677,8 @@ final class MailboxTest extends TestCase
         } elseif ('assertNull' == $assertMethod) {
             $this->assertNull($mailbox->setConnectionArgs($option, $retriesNum, $param));
         }
+
+        $mailbox->disconnect();
     }
 
     /**

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -10,6 +10,7 @@ namespace PhpImap;
 
 use const CL_EXPUNGE;
 use DateTime;
+use Generator;
 use const IMAP_CLOSETIMEOUT;
 use const IMAP_OPENTIMEOUT;
 use const IMAP_READTIMEOUT;
@@ -599,31 +600,44 @@ final class MailboxTest extends TestCase
     /**
      * Provides test data for testing connection args.
      *
-     * @psalm-return list<array{0:'assertNull'|'expectException', 1:int, 2:int, 3:array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty>}>
+     * @psalm-return Generator<string, array{0:'assertNull'|'expectException', 1:int, 2:int, 3:array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty>}>
      */
-    public function connectionArgsProvider(): array
+    public function connectionArgsProvider(): Generator
     {
-        /** @psalm-var list<array{0:'assertNull'|'expectException', 1:int, 2:int, 3:array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty>}> */
-        return [
+        yield from [
+            'readonly, disable gssapi' =>
             ['assertNull', OP_READONLY, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            ['assertNull', OP_READONLY, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'anonymous, disable gssapi' =>
             ['assertNull', OP_ANONYMOUS, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'half open, disable gssapi' =>
             ['assertNull', OP_HALFOPEN, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'expunge on close, disable gssapi' =>
             ['assertNull', CL_EXPUNGE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'debug, disable gssapi' =>
             ['assertNull', OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'short cache, disable gssapi' =>
             ['assertNull', OP_SHORTCACHE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'silent, disable gssapi' =>
             ['assertNull', OP_SILENT, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'return driver prototype, disable gssapi' =>
             ['assertNull', OP_PROTOTYPE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'don\'t do non-secure authentication, disable gssapi' =>
             ['assertNull', OP_SECURE, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, disable gssapi, 1 retry' =>
             ['assertNull', OP_READONLY, 1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, disable gssapi, 3 retries' =>
             ['assertNull', OP_READONLY, 3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, disable gssapi, 12 retries' =>
             ['assertNull', OP_READONLY, 12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-
+            'readonly debug, disable gssapi' =>
             ['expectException', OP_READONLY | OP_DEBUG, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, -1 retries' =>
             ['expectException', OP_READONLY, -1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, -3 retries' =>
             ['expectException', OP_READONLY, -3, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, -12 retries' =>
             ['expectException', OP_READONLY, -12, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
-            ['expectException', OP_READONLY, -1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
+            'readonly, null options' =>
             ['expectException', OP_READONLY, 0, [null]],
         ];
     }


### PR DESCRIPTION
fix for #510 

* [x] draft pending #504 
* d33cde8 23500a0 facilitate having the non-exception tests perform assertions again (used to be null return, now void return, fixture class gives it something useful to check).
* 252ac48 removes duplicate test cases & switches to generator to allow tests to be dynamically compiled without dumping the array all at once.
* 76aca70 generator keys were prepended on previous lines to separate the diff from the commit that satisfies php-cs-fixer
* 96c241e dynamically compiles a bunch of mostly-exhaustive combinations for testing (don't think it's entirely exhaustive but close enough)
* 7077fcc allow bitmask options, as per [discussion on issue](https://github.com/barbushin/php-imap/issues/510#issuecomment-633208704)
* e08ea90 add example of bitmask usage [as per request](https://github.com/barbushin/php-imap/issues/510#issuecomment-633208704)
* 5002f4c explicitly disconnect during testing as a habit to get into (even though this particular test doesn't actually make a connection)