### PR TITLE
Unexpected T_MATCH

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "psalm/plugin-phpunit": "^0.10.0",
         "roave/security-advisories": "dev-master",
         "sebastian/phpcpd": "^4.1",
-        "vimeo/psalm": "^3.11.6"
+        "vimeo/psalm": "^3.12"
     },
     "scripts": {
         "static-analysis": [

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "friendsofphp/php-cs-fixer": "^2.16",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "maglnet/composer-require-checker": "^2.0",
+        "nikic/php-parser": "^4.3,<4.7",
         "paragonie/hidden-string": "^1.0",
         "phpunit/phpunit": "^8.5",
         "povils/phpmnd": "^2.2",

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -12,11 +12,6 @@
       <code>\is_resource($maybe)</code>
     </DocblockTypeContradiction>
   </file>
-  <file src="src/PhpImap/IncomingMail.php">
-    <PropertyTypeCoercion occurrences="1">
-      <code>$this-&gt;dataInfo</code>
-    </PropertyTypeCoercion>
-  </file>
   <file src="src/PhpImap/Mailbox.php">
     <DocblockTypeContradiction occurrences="2">
       <code>\in_array($imapSearchOption, $supported_options, true)</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -19,10 +19,7 @@
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="3">
       <code>$element-&gt;charset</code>
-      <code>$element-&gt;charset</code>
       <code>$element-&gt;text</code>
-      <code>$element-&gt;charset</code>
-      <code>$element-&gt;charset</code>
       <code>$element-&gt;text</code>
     </InvalidArgument>
     <PossiblyUnusedMethod occurrences="24">

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.11.6@7fc1f50f54bd6b174b1c43a37c1b0b151915d55c">
+<files psalm-version="3.12.2@7c7ebd068f8acaba211d4a2c707c4ba90874fa26">
   <file src="examples/get_and_parse_all_emails_without_saving_attachments.php">
     <UnusedVariable occurrences="1">
       <code>$mailbox</code>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -54,4 +54,11 @@
       <code>self::ANYTHING</code>
     </InvalidArgument>
   </file>
+  <file src="vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php">
+    <ParseError occurrences="3">
+      <code>Match</code>
+      <code>;</code>
+      <code>;</code>
+    </ParseError>
+  </file>
 </files>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -54,11 +54,4 @@
       <code>self::ANYTHING</code>
     </InvalidArgument>
   </file>
-  <file src="vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php">
-    <ParseError occurrences="3">
-      <code>Match</code>
-      <code>;</code>
-      <code>;</code>
-    </ParseError>
-  </file>
 </files>


### PR DESCRIPTION
"Match" becoming a reserved word currently makes travis fail.

~psalm baseline~ version constraint needs to be revisted pending outcome of nikic/PHP-Parser#690