### PR TITLE
Add false and null to possible (magic) property filePath property type in IncomingMailAttachment

### DIFF
--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -14,7 +14,7 @@ use UnexpectedValueException;
  *
  * @author Barbushin Sergey http://linkedin.com/in/barbushin
  *
- * @property string $filePath lazy attachment data file
+ * @property string|false|null $filePath lazy attachment data file
  *
  * @psalm-type fileinfoconst = 0|2|16|1024|1040|8|32|128|256|16777216
  */


### PR DESCRIPTION
As the __get() method could also return null or false for the filePath property, these types should be added to the @property annotation.