### PR TITLE
Fix for #525 How to detect textPlain encoding

### DIFF
--- a/src/PhpImap/DataPartInfo.php
+++ b/src/PhpImap/DataPartInfo.php
@@ -109,7 +109,8 @@ class DataPartInfo
     {
         if (isset($this->charset) and !empty(\trim($this->charset))) {
             $this->data = $this->mail->decodeMimeStr(
-                (string) $this->data // Data to convert
+                (string) $this->data, // Data to convert
+                (string) \trim($this->charset)
             );
         }
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1333,6 +1333,7 @@ class Mailbox
      * Decodes a mime string.
      *
      * @param string $string MIME string to decode
+     * @param string|null $charsetPreferred The charset of the data part info if it was set
      *
      * @return string Converted string if conversion was successful, or the original string if not
      *
@@ -1340,7 +1341,7 @@ class Mailbox
      *
      * @todo update implementation pending resolution of https://github.com/vimeo/psalm/issues/2619 & https://github.com/vimeo/psalm/issues/2620
      */
-    public function decodeMimeStr(string $string): string
+    public function decodeMimeStr(string $string, ?string $charsetPreferred = null): string
     {
         $newString = '';
         /** @var list<object{charset?:string, text?:string}>|false */
@@ -1354,7 +1355,7 @@ class Mailbox
             $charset = \strtolower($element->charset);
 
             if ('default' === $charset) {
-                $charset = $this->decodeMimeStrDefaultCharset;
+                $charset = !empty($charsetPreferred) ? $charsetPreferred : $this->decodeMimeStrDefaultCharset;
             }
 
             switch ($charset) {


### PR DESCRIPTION
The decodeMimeStr now uses the encoding from DataPartInfo.php if it was set