### PR TITLE
569: Fix broken inline images when header does not contain "Content-Disposition: inline"

### DIFF
--- a/src/PhpImap/IncomingMail.php
+++ b/src/PhpImap/IncomingMail.php
@@ -219,7 +219,11 @@ class IncomingMail extends IncomingMailHeader
                 $cid = \str_replace('cid:', '', $match);
 
                 foreach ($attachments as $attachment) {
-                    if ($attachment->contentId == $cid && 'inline' == \mb_strtolower((string) $attachment->disposition)) {
+                    /**
+                     * Inline images can contain a "Content-Disposition: inline", but only a "Content-ID" is also enough.
+                     * See https://github.com/barbushin/php-imap/issues/569
+                     */
+                    if ($attachment->contentId == $cid || 'inline' == \mb_strtolower((string) $attachment->disposition)) {
                         $contents = $attachment->getContents();
                         $contentType = (string) $attachment->getFileInfo(FILEINFO_MIME);
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1636,7 +1636,7 @@ class Mailbox
             }
         }
 
-        $isAttachment = isset($params['filename']) || isset($params['name']);
+        $isAttachment = isset($params['filename']) || isset($params['name']) || isset($partStructure->id);
 
         $dispositionAttachment = (
             isset($partStructure->disposition) &&


### PR DESCRIPTION
See https://github.com/barbushin/php-imap/issues/569.