### PR TITLE
Adding link to PHP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,11 @@ echo "\n\nAttachments:\n";
 print_r($mail->getAttachments());
 ```
 
-Method imap() allows to call any imap function in a context of the the instance:
+Method `imap()` allows to call any [PHP IMAP function](https://www.php.net/manual/ref.imap.php) in a context of the instance. Example:
 
 ```php
-// Call imap_check();
-// http://php.net/manual/en/function.imap-check.php
-$info = $mailbox->imap('check'); //
+// Call imap_check() - see http://php.net/manual/function.imap-check.php
+$info = $mailbox->imap('check');
 
 // Show current time for the mailbox
 $currentServerTime = isset($info->Date) && $info->Date ? date('Y-m-d H:i:s', strtotime($info->Date)) : 'Unknown';


### PR DESCRIPTION
Hold on!
Does this method really exist?? Cause `$mailbox->imap('mailboxmsginfo');` is giving me:

> Attempted to call an undefined method named "imap" of class "PhpImap\Mailbox".