### PR TITLE
Add FILEINFO_MIME_TYPE support (fix incorrect bugfix)

### DIFF
--- a/src/PhpImap/IncomingMail.php
+++ b/src/PhpImap/IncomingMail.php
@@ -225,7 +225,7 @@ class IncomingMail extends IncomingMailHeader
                      */
                     if ($attachment->contentId == $cid || 'inline' == \mb_strtolower((string) $attachment->disposition)) {
                         $contents = $attachment->getContents();
-                        $contentType = (string) $attachment->getFileInfo(FILEINFO_MIME);
+                        $contentType = (string) $attachment->getFileInfo(FILEINFO_MIME_TYPE);
 
                         if (!\strstr($contentType, 'image')) {
                             continue;

--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpImap;
 
-use const FILEINFO_MIME;
 use const FILEINFO_NONE;
 use finfo;
 use UnexpectedValueException;
@@ -75,7 +74,7 @@ class IncomingMailAttachment
     private $dataInfo;
 
     /** @var string|null */
-    private $mimeType;
+    public $mimeType;
 
     /** @var string|null */
     private $filePath;
@@ -131,10 +130,6 @@ class IncomingMailAttachment
      */
     public function getFileInfo(int $fileinfo_const = FILEINFO_NONE): string
     {
-        if ((FILEINFO_MIME == $fileinfo_const) && (false != $this->mimeType)) {
-            return $this->mimeType;
-        }
-
         $finfo = new finfo($fileinfo_const);
 
         return $finfo->buffer($this->getContents());

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1308,6 +1308,7 @@ class Mailbox
         $attachment->fileInfoRaw = $attachment->getFileInfo(FILEINFO_RAW);
         $attachment->fileInfo = $attachment->getFileInfo(FILEINFO_NONE);
         $attachment->mime = $attachment->getFileInfo(FILEINFO_MIME);
+        $attachment->mimeType = $attachment->getFileInfo(FILEINFO_MIME_TYPE);
         $attachment->mimeEncoding = $attachment->getFileInfo(FILEINFO_MIME_ENCODING);
         $attachment->fileExtension = $attachment->getFileInfo(FILEINFO_EXTENSION);
 


### PR DESCRIPTION
In **src/PhpImap/IncomingMailAttachment.php**
```php
if ((FILEINFO_MIME == $fileinfo_const) && (false != $this->mimeType)) {
            return $this->mimeType;
}
```
$this->mimeType - currently never set, condition always false. Deleted as unnecessary.

Added default field definition in **src/PhpImap/Mailbox.php**

```php 
$attachment->mimeType = $attachment->getFileInfo(FILEINFO_MIME_TYPE);
```

Also i found incorrect use of mime type in **src/PhpImap/IncomingMail.php -> embedImageAttachments()**

```php
$contentType = (string) $attachment->getFileInfo(FILEINFO_MIME);
$base64encoded = \base64_encode($contents);
$replacement = 'data:'.$contentType.';base64, '.$base64encoded;
```
For example for jpeg image **FILEINFO_MIME** is **image/jpeg; charset=binary**, and for correct base64 need only mime type (without encoding) **FILEINFO_MIME_TYPE** -> **image/jpeg**

