### PR TITLE
fix php 8.0 sort

### DIFF
--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -908,7 +908,7 @@ final class Imap
         \imap_errors(); // flush errors
 
         $imap_stream = self::EnsureConnection($imap_stream, __METHOD__, 1);
-        $reverse = (int) $reverse;
+        $reverse = (bool) $reverse;
 
         /** @var int */
         $criteria = $criteria;


### PR DESCRIPTION
```
Fatal error: Uncaught TypeError: imap_sort(): Argument #3 ($reverse) must be of type bool, int given
```

https://github.com/barbushin/php-imap/issues/563#issuecomment-867584500