### PR TITLE
Hacking PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2 || ^8.0 <8.1",
+        "php": "^7.2 || ^8.0",
         "ext-fileinfo": "*",
         "ext-iconv": "*",
         "ext-imap": "*",

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -1079,7 +1079,7 @@ final class Imap
      */
     private static function EnsureResource($maybe, string $method, int $argument)
     {
-        if (!$maybe || !\is_resource($maybe)) {
+        if (!$maybe || (!\is_resource($maybe) && !$maybe instanceof \IMAP\Connection)) {
             throw new InvalidArgumentException('Argument '.(string) $argument.' passed to '.$method.' must be a valid resource!');
         }
 


### PR DESCRIPTION
Quick & dirty.
But since https://php.watch/versions/8.1/IMAPConnection-resource says:
> All functions that previously accepted resources accept the new type as well. 

This might indeed be all that's needed - at least it works for me ;-)

Closes https://github.com/barbushin/php-imap/issues/624