### PR TITLE
Dynamically test PHP versions depending on composer.json

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,13 +7,38 @@ on:
     branches: [ develop ]
 
 jobs:
+  provide_php_versions_json:
+    runs-on: ubuntu-20.04
+
+    steps:
+      # git clone + use PHP + composer install
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+
+      - uses: "ramsey/composer-install@v1"
+
+      # to see the output
+      - run: vendor/bin/easy-ci php-versions-json
+
+      # here we create the json, we need the "id:" so we can use it in "outputs" bellow
+      -
+        id: output_data
+        run: echo "::set-output name=matrix::$(vendor/bin/easy-ci php-versions-json)"
+
+    # here, we save the result of this 1st phase to the "outputs"
+    outputs:
+        matrix: ${{ steps.output_data.outputs.matrix }}
+
   static-analysis:
-    name: Static Analysis
+    name: Static Analysis PHP ${{ matrix.php-versions }}
     runs-on: ${{ matrix.operating-system }}
+    needs: provide_php_versions_json
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'ubuntu-20.04']
-        php-versions: ['7.2.0', '7.2', '7.3', '7.4', '8.0', '8.1.0',]
+        php-versions: ${{ fromJson(needs.provide_php_versions_json.outputs.matrix) }}
 
     steps:
     - name: Setup PHP
@@ -49,12 +74,13 @@ jobs:
       run: composer run static-analysis
 
   phpunit:
-    name: PHP Unit Tests
+    name: PHP ${{ matrix.php-versions }} Unit Tests
     runs-on: ${{ matrix.operating-system }}
+    needs: provide_php_versions_json
     strategy:
       matrix:
         operating-system: ['ubuntu-latest', 'ubuntu-20.04']
-        php-versions: ['7.2.0', '7.2', '7.3', '7.4', '8.0', '8.1.0',]
+        php-versions: ${{ fromJson(needs.provide_php_versions_json.outputs.matrix) }}
 
     steps:
     - name: Setup PHP

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,8 @@
         "psalm/plugin-phpunit": "^0.10.0|^0.15.1",
         "roave/security-advisories": "dev-master",
         "sebastian/phpcpd": "^4.1|^6.0",
+        "symfony/symfony": "^5.4",
+        "symplify/easy-ci": "^9.4",
         "vimeo/psalm": "^4.7"
     },
     "scripts": {


### PR DESCRIPTION
To avoid updating all the time the Github workflow config, this change should dynamically load and test the respective PHP versions, which are supported / defined by the `composer.json`.

Avoids pull requests like #642 in the future.