### PR TITLE
Fix deprecated coverage XML config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-         bootstrap="vendor/autoload.php"
-         verbose="true"
-         stopOnError="false"
-         stopOnFailure="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         colors="true"
-         forceCoversAnnotation="false"
-         processIsolation="false">
-    <testsuites>
-        <testsuite name="php-imap Tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-	</whitelist>
-    </filter>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="vendor/autoload.php"
+    verbose="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    colors="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="php-imap Tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Fixes the following deprecation warning:
```shell
/home/runner/work/php-imap/php-imap/vendor/bin/phpunit --testdox --stop-on-failure --coverage-clover=clover.xml
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.13 with Xdebug 3.1.1
Configuration: /home/runner/work/php-imap/php-imap/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```