### PR TITLE
Fix Issue 519 PHP unit test

### DIFF
--- a/tests/unit/Fixtures/IncomingMailAttachment.php
+++ b/tests/unit/Fixtures/IncomingMailAttachment.php
@@ -4,22 +4,22 @@ declare(strict_types=1);
 
 namespace PhpImap\Fixtures;
 
-use const FILEINFO_MIME;
+use const FILEINFO_MIME_TYPE;
 use const FILEINFO_NONE;
 use PhpImap\IncomingMailAttachment as Base;
 
 class IncomingMailAttachment extends Base
 {
     /** @var string|null */
-    public $override_getFileInfo_mime = null;
+    public $override_getFileInfo_mime_type = null;
 
     public function getFileInfo(int $fileinfo_const = FILEINFO_NONE): string
     {
         if (
-            FILEINFO_MIME === $fileinfo_const &&
-            isset($this->override_getFileInfo_mime)
+            FILEINFO_MIME_TYPE === $fileinfo_const &&
+            isset($this->override_getFileInfo_mime_type)
         ) {
-            return $this->override_getFileInfo_mime;
+            return $this->override_getFileInfo_mime_type;
         }
 
         return parent::getFileInfo($fileinfo_const);

--- a/tests/unit/Issue519Test.php
+++ b/tests/unit/Issue519Test.php
@@ -96,7 +96,7 @@ class Issue519Test extends TestCase
 
     public const HTML_EMBED = '<img src="data:image/jpeg;base64, ">';
 
-    public const MIME = 'image/jpeg';
+    public const MIME_TYPE = 'image/jpeg';
 
     public const EXPECTED_ATTACHMENT_COUNT = 1;
 
@@ -154,7 +154,7 @@ class Issue519Test extends TestCase
         $attachment->name = self::ID;
         $attachment->sizeInBytes = self::SIZE_IN_BYTES;
         $attachment->disposition = $header_value;
-        $attachment->override_getFileInfo_mime = self::MIME;
+        $attachment->override_getFileInfo_mime_type = self::MIME_TYPE;
 
         $attachment->addDataPartInfo($part);
 


### PR DESCRIPTION
This fixes the following PHP unit error:
```shell
Issue519 (PhpImap\Issue519)
 ✘  with data set "inline" [0.56 ms]
   │
   │ Failed asserting that actual size 1 matches expected size 0.
   │
   │ /home/runner/work/php-imap/php-imap/tests/unit/Issue519Test.php:177
   │
```

This was caused and is related to the pull request #623.