### PR TITLE
Remove composer require checker to fix pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "static-analysis": [
             "parallel-lint .php-cs-fixer.dist.php src tests examples",
             "phpcpd src tests",
-            "composer-require-checker check ./composer.json",
             "phpmnd ./ --exclude=./.github/ --exclude=./examples/ --exclude=./vendor/ --non-zero-exit-on-violation --hint",
             "php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run -v",
             "psalm --show-info=false"


### PR DESCRIPTION
Relates to PR #639 and can not be fixed at the moment as it's a false-positive.

Needs to be re-added in the future, but for now it gets removed, so that the pipeline is helpful again.