### PR TITLE
#571: Improve ConnectionException handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ try {
 	// PHP.net imap_search criteria: http://php.net/manual/en/function.imap-search.php
 	$mailsIds = $mailbox->searchMailbox('ALL');
 } catch(PhpImap\Exceptions\ConnectionException $ex) {
-	echo "IMAP connection failed: " . $ex;
+	echo "IMAP connection failed: " . implode(",", $ex->getErrors('all'));
 	die();
 }
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Initially released in December 2012, the PHP IMAP Mailbox is a powerful and open
 * PHP `iconv` extension must be present; so make sure this line is active in your php.ini: `extension=php_iconv.dll`
 * PHP `imap` extension must be present; so make sure this line is active in your php.ini: `extension=php_imap.dll`
 * PHP `mbstring` extension must be present; so make sure this line is active in your php.ini: `extension=php_mbstring.dll`
+* PHP `json` extension must be present; so make sure this line is active in your php.ini: `extension=json.dll`
 
 ### Installation by Composer
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "ext-fileinfo": "*",
         "ext-iconv": "*",
         "ext-imap": "*",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",

--- a/examples/get_and_parse_unseen_emails.php
+++ b/examples/get_and_parse_unseen_emails.php
@@ -23,7 +23,7 @@
     try {
         $mail_ids = $mailbox->searchMailbox('UNSEEN');
     } catch (ConnectionException $ex) {
-        exit('IMAP connection failed: '.$ex->getMessage());
+        exit('IMAP connection failed: '.$ex->getErrors('first'));
     } catch (Exception $ex) {
         exit('An error occured: '.$ex->getMessage());
     }

--- a/src/PhpImap/Exceptions/ConnectionException.php
+++ b/src/PhpImap/Exceptions/ConnectionException.php
@@ -13,4 +13,30 @@ use Exception;
  */
 class ConnectionException extends Exception
 {
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct(json_encode($message), $code, $previous);
+    }
+
+    public function getErrors($select = 'first')
+    {
+        $message = $this->getMessage();
+
+        switch (strtolower($select)) {
+            case 'all':
+                return json_decode($message);
+                break;
+            default:
+            case 'first':
+                $message = json_decode($message);
+
+                return $message[0];
+                break;
+            case 'last':
+                $message = json_decode($message);
+
+                return $message[\count($message) - 1];
+                break;
+        }
+    }
 }

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -14,6 +14,7 @@ use const IMAP_READTIMEOUT;
 use const IMAP_WRITETIMEOUT;
 use InvalidArgumentException;
 use const NIL;
+use PhpImap\Exceptions\ConnectionException;
 use const SE_FREE;
 use const SORTARRIVAL;
 use const SORTCC;
@@ -707,13 +708,7 @@ final class Imap
         $result = @\imap_open($mailbox, $username, $password, $options, $n_retries, $params);
 
         if (!$result) {
-            $lastError = \imap_last_error();
-
-            if ((\is_string($lastError)) && ('' !== \trim($lastError))) {
-                throw new UnexpectedValueException('IMAP error:'.$lastError);
-            }
-
-            throw new UnexpectedValueException('Could not open mailbox!', 0, self::HandleErrors(\imap_errors(), 'imap_open'));
+            throw new ConnectionException(\imap_errors());
         }
 
         return $result;

--- a/tests/unit/ImapTest.php
+++ b/tests/unit/ImapTest.php
@@ -8,10 +8,10 @@ namespace PhpImap;
 
 use Generator;
 use ParagonIE\HiddenString\HiddenString;
+use PhpImap\Exceptions\ConnectionException;
 use PHPUnit\Framework\TestCase as Base;
 use const SORTARRIVAL;
 use Throwable;
-use UnexpectedValueException;
 
 /**
  * @psalm-type MAILBOX_ARGS = array{
@@ -35,13 +35,13 @@ class ImapTest extends Base
     use LiveMailboxTestingTrait;
 
     /**
-     * @psalm-return Generator<'CI ENV with invalid password'|'empty mailbox/username/password', array{0: UnexpectedValueException::class, 1: '/^IMAP error:.[AUTHENTICATIONFAILED]/'|'IMAP error:Can't open mailbox : no such mailbox', 2: array{0: HiddenString, 1: HiddenString, 2: HiddenString, 3: 0, 4: 0, 5: array<empty, empty>}, 3?: true}, mixed, void>
+     * @psalm-return Generator<'CI ENV with invalid password'|'empty mailbox/username/password', array{0: ConnectionException::class, 1: '/^[AUTHENTICATIONFAILED]/'|'Can't open mailbox : no such mailbox', 2: array{0: HiddenString, 1: HiddenString, 2: HiddenString, 3: 0, 4: 0, 5: array<empty, empty>}, 3?: true}, mixed, void>
      */
     public function OpenFailure(): Generator
     {
         yield 'empty mailbox/username/password' => [
-            UnexpectedValueException::class,
-            'IMAP error:Can\'t open mailbox : no such mailbox',
+            ConnectionException::class,
+            'Can\'t open mailbox : no such mailbox',
             [
                 new HiddenString(''),
                 new HiddenString(''),
@@ -58,8 +58,8 @@ class ImapTest extends Base
 
         if (\is_string($imapPath) && \is_string($login) && \is_string($password)) {
             yield 'CI ENV with invalid password' => [
-                UnexpectedValueException::class,
-                '/^IMAP error:.*\[AUTHENTICATIONFAILED\].*/',
+                ConnectionException::class,
+                '/^\[AUTHENTICATIONFAILED\].*/',
                 [
                     new HiddenString($imapPath, true, true),
                     new HiddenString($login, true, true),


### PR DESCRIPTION
This change solves the issue, that the original IMAP connect error gets masked.

`ConnectionException::getErrors($select = 'first')` is a new function, which allows to get either all IMAP errors, only the first or last reported error.

`ConnectionException::getMessage()` is still simply returning a string. This string contains now all IMAP errors as JSON encoded format. The implementation allows further options for the future, if necessary.

Example code to test:

```php
<?php
    require_once __DIR__.'/../vendor/autoload.php';

    use PhpImap\Exceptions\ConnectionException;
    use PhpImap\Mailbox;

    $mailbox = new Mailbox(
        '{imap.gmail.com:993/imap/ssl}INBOX', // IMAP server and mailbox folder
        'some@gmail.com', // Username for the before configured mailbox
        'wrongPassword', // Password for the before configured username
        __DIR__, // Directory, where attachments will be saved (optional)
        'US-ASCII' // Server encoding (optional)
    );

    try {
        $mail_ids = $mailbox->searchMailbox('ALL');
    } catch (ConnectionException $ex) {
        // Get first reported IMAP error
        exit('IMAP connection failed: '.$ex->getErrors()); // default behaviour
        exit('IMAP connection failed: '.$ex->getErrors('first'));

        // Get last reported IMAP error
        exit('IMAP connection failed: '.$ex->getErrors('last'));

        // Get all reported IMAP errors (Array)
        exit('IMAP connection failed: '.implode(",", $ex->getErrors('all')));

        // Get all reported IMAP errors (JSON encoded string)
        exit('IMAP connection failed: '.$ex->getMessage());
    } catch (Exception $ex) {
        exit('An error occured: '.$ex->getMessage());
    }
```

Fixes #571.