### PR TITLE
#529: Add email flags as properties

### DIFF
--- a/src/PhpImap/IncomingMailHeader.php
+++ b/src/PhpImap/IncomingMailHeader.php
@@ -21,6 +21,21 @@ class IncomingMailHeader
     public $mailboxFolder;
 
     /** @var bool */
+    public $isSeen = false;
+
+    /** @var bool */
+    public $isAnswered = false;
+
+    /** @var bool */
+    public $isRecent = false;
+
+    /** @var bool */
+    public $isFlagged = false;
+
+    /** @var bool */
+    public $isDeleted = false;
+
+    /** @var bool */
     public $isDraft = false;
 
     /** @var string|null */

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -835,6 +835,30 @@ class Mailbox
     }
 
     /**
+     * Check, if the specified flag for the mail is set or not.
+     *
+     * @param int    $mailsId A single mail ID
+     * @param string $flag    Which you can get are \Seen, \Answered, \Flagged, \Deleted, and \Draft as defined by RFC2060
+     *
+     * @return bool True, when the flag is set, false when not
+     *
+     * @psalm-param list<int> $mailId
+     */
+    public function flagIsSet(int $mailId, string $flag): bool
+    {
+        $flag = str_replace('\\', '', strtolower($flag));
+
+        $overview = Imap::fetch_overview($this->getImapStream(), $mailId, ST_UID);
+
+        if ($overview[0]->$flag == 1)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Causes a store to add the specified flag to the flags set for the mails in the specified sequence.
      *
      * @param array  $mailsIds Array of mail IDs
@@ -1141,7 +1165,12 @@ class Mailbox
         $header->id = $mailId;
         $header->imapPath = $this->imapPath;
         $header->mailboxFolder = $this->mailboxFolder;
-        $header->isDraft = (!isset($head->date)) ? true : false;
+        $header->isSeen = ($this->flagIsSet($mailId, '\Seen')) ? true : false;
+        $header->isAnswered = ($this->flagIsSet($mailId, '\Answered')) ? true : false;
+        $header->isRecent = ($this->flagIsSet($mailId, '\Recent')) ? true : false;
+        $header->isFlagged = ($this->flagIsSet($mailId, '\Flagged')) ? true : false;
+        $header->isDeleted = ($this->flagIsSet($mailId, '\Deleted')) ? true : false;
+        $header->isDraft = ($this->flagIsSet($mailId, '\Draft')) ? true : false;
         $header->mimeVersion = $this->getMailHeaderFieldValue($headersRaw, 'MIME-Version');
         $header->xVirusScanned = $this->getMailHeaderFieldValue($headersRaw, 'X-Virus-Scanned');
         $header->organization = $this->getMailHeaderFieldValue($headersRaw, 'Organization');


### PR DESCRIPTION
This change adds all available email flags as property:
- `Seen` (email property `isSeen`)
- `Answered` (email property `isAnswered`)
- `Recent` (email property `isRecent`)
- `Flagged` (email property `isFlagged`)
- `Deleted` (email property `isDeleted`)
- `Draft` (email property `isDraft`)

Those can be accessed like this:

```php
<?php
    require_once __DIR__.'/../vendor/autoload.php';

    use PhpImap\Exceptions\ConnectionException;
    use PhpImap\Mailbox;

    $mailbox = new Mailbox(
        '{imap.gmail.com:993/imap/ssl}INBOX', // IMAP server and mailbox folder
        'some@gmail.com', // Username for the before configured mailbox
        '*********', // Password for the before configured username
        __DIR__, // Directory, where attachments will be saved (optional)
        'US-ASCII' // Server encoding (optional)
    );

    try {
        $mail_ids = $mailbox->searchMailbox('ALL');
    } catch (ConnectionException $ex) {
        exit('IMAP connection failed: '.$ex->getErrors('first'));
    } catch (Exception $ex) {
        exit('An error occured: '.$ex->getMessage());
    }

    foreach ($mail_ids as $mail_id) {
        echo "+------ P A R S I N G ------+\n";

        $email = $mailbox->getMail(
            $mail_id, // ID of the email, you want to get
            false // Do NOT mark emails as seen (optional)
        );

        echo 'mail has been seen? ';
        if ($email->isSeen) {
            echo "Yes\n";
        } else {
            echo "No\n";
        }

        echo 'mail has been answered? ';
        if ($email->isAnswered) {
            echo "Yes\n";
        } else {
            echo "No\n";
        }

        echo 'mail is a draft? ';
        if ($email->isDraft) {
            echo "Yes\n";
        } else {
            echo "No\n";
        }
    }

    $mailbox->disconnect();
```

Solves #529.