### PR TITLE
#655: Add missing PHP 8.1 support

### DIFF
--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -721,7 +721,7 @@ final class Imap
      */
     public static function ping($imap_stream): bool
     {
-        return \is_resource($imap_stream) && \imap_ping($imap_stream);
+        return (\is_resource($imap_stream) || $imap_stream instanceof \IMAP\Connection) && \imap_ping($imap_stream);
     }
 
     /**

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -476,7 +476,7 @@ class Mailbox
 
     public function hasImapStream(): bool
     {
-        return \is_resource($this->imapStream) && \imap_ping($this->imapStream);
+        return (\is_resource($this->imapStream) || $this->imapStream instanceof \IMAP\Connection) && \imap_ping($this->imapStream);
     }
 
     /**


### PR DESCRIPTION
IMAP stream can be an IMAP resource or IMAP\Connection object. See https://www.php.net/manual/en/migration81.incompatible.php for further information.

Looks like as this has been forgotten when adding PHP 8.1 support in the past.

Solves #655.

---

Tested with different PHP major versions and the identical code: All versions were able to get the same emails incl. attachments and it always took around 10 seconds for 25 emails.

```shell
$ /c/PHP/7.3.12-nts/php.exe testing.php
Trying to connect to '{outlook.office365.com:993/imap/ssl}INBOX'...
Found 25 email(s)...
Total attachments: 26
time for getting mail Is: 9.846657037735 sec.
```

```shell
$ /c/PHP/7.4.26-nts/php.exe testing.php
Trying to connect to '{outlook.office365.com:993/imap/ssl}INBOX'...
Found 25 email(s)...
Total attachments: 26
time for getting mail Is: 10.306457996368 sec.
```

```shell
$ /c/PHP/8.0.13-nts/php.exe testing.php
Trying to connect to '{outlook.office365.com:993/imap/ssl}INBOX'...
Found 25 email(s)...
Total attachments: 26
time for getting mail Is: 9.220538854599 sec.
```

```shell
$ /c/PHP/8.1.0-nts/php.exe testing.php
Trying to connect to '{outlook.office365.com:993/imap/ssl}INBOX'...
Found 25 email(s)...
Total attachments: 26
time for getting mail Is: 9.7392268180847 sec.
```