### PR TITLE
BUG: An argument $reverse of method \PhpImap\Imap::sort() has type boolean from PHP version 8 only

### DIFF
--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -23,6 +23,7 @@ use const SORTFROM;
 use const SORTSIZE;
 use const SORTSUBJECT;
 use const SORTTO;
+use const PHP_MAJOR_VERSION;
 use stdClass;
 use Throwable;
 use UnexpectedValueException;
@@ -912,8 +913,15 @@ final class Imap
 
         $imap_stream = self::EnsureConnection($imap_stream, __METHOD__, 1);
 
+        /** @var int */
+        $criteria = $criteria;
+
         if(PHP_MAJOR_VERSION < 8) {
+            /** @var int */
             $reverse = (int)$reverse;
+        } else {
+            /** @var bool */
+            $reverse = $reverse;
         }
 
         if (null !== $search_criteria && null !== $charset) {

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -14,6 +14,7 @@ use const IMAP_READTIMEOUT;
 use const IMAP_WRITETIMEOUT;
 use InvalidArgumentException;
 use const NIL;
+use const PHP_MAJOR_VERSION;
 use PhpImap\Exceptions\ConnectionException;
 use const SE_FREE;
 use const SORTARRIVAL;
@@ -23,7 +24,6 @@ use const SORTFROM;
 use const SORTSIZE;
 use const SORTSUBJECT;
 use const SORTTO;
-use const PHP_MAJOR_VERSION;
 use stdClass;
 use Throwable;
 use UnexpectedValueException;
@@ -916,9 +916,9 @@ final class Imap
         /** @var int */
         $criteria = $criteria;
 
-        if(PHP_MAJOR_VERSION < 8) {
+        if (PHP_MAJOR_VERSION < 8) {
             /** @var int */
-            $reverse = (int)$reverse;
+            $reverse = (int) $reverse;
         } else {
             /** @var bool */
             $reverse = $reverse;

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -911,10 +911,10 @@ final class Imap
         \imap_errors(); // flush errors
 
         $imap_stream = self::EnsureConnection($imap_stream, __METHOD__, 1);
-        $reverse = $reverse;
 
-        /** @var int */
-        $criteria = $criteria;
+        if(PHP_MAJOR_VERSION < 8) {
+            $reverse = (int)$reverse;
+        }
 
         if (null !== $search_criteria && null !== $charset) {
             $result = \imap_sort(


### PR DESCRIPTION
**Environment (please complete the following information):**
 - PHP IMAP version: 7.4.27
 - PHP Version: 7.4.27
 - Type of execution: CLI

**Describe the bug**

The $reverse variable type conversion from boolean to integer has been removed in this [commit](https://github.com/barbushin/php-imap/commit/2cd5d0bcf4500f4cc70559a103d65a72b512700b), but imap_open() before PHP version 8 only accepts integer type. Thus, in PHP 7 this code ends with the error:

```
imap_sort() expects parameter 3 to be int, bool given at /var/www/virtual/site/htdocs/vendor/php-imap/php-imap/src/PhpImap/Imap.php:934
```

Also i found strange assignment in \PhpImap\Imap::sort():

```
        /** @var int */
        $criteria = $criteria;
```

I've added PHP version detection and removed legacy code.

Please review it.

Thank you!