### PR TITLE
Drop support for EoL PHP versions

### DIFF
--- a/.github/workflows/php_code_coverage.yml
+++ b/.github/workflows/php_code_coverage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-20.04']
-        php-versions: ['8.0']
+        php-versions: ['8.1']
 
     steps:
     - name: Setup PHP

--- a/.github/workflows/php_static_analysis.yml
+++ b/.github/workflows/php_static_analysis.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-20.04']
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
     - name: Setup PHP

--- a/.github/workflows/php_unit_tests.yml
+++ b/.github/workflows/php_unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-20.04']
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
     - name: Setup PHP

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Initially released in December 2012, the PHP IMAP Mailbox is a powerful and open
 
 ### Requirements
 
-| PHP Version  | php-imap Version |
-| ------------- | ------------- |
-| 5.6  | 3.x  |
-| 7.0  | 3.x  |
-| 7.1  | 3.x  |
-| 7.2  | 3.x, 4.x |
-| 7.3  | 3.x, 4.x |
-| 7.4  | >3.0.33, 4.x |
-| 8.0  | >3.0.33, 4.x |
-| 8.1  | >4.3.0 |
+| PHP Version  | php-imap Version | php-imap status |
+| ------------- | ------------- | ------------- |
+| 5.6  | 3.x  | End of life |
+| 7.0  | 3.x  | End of life |
+| 7.1  | 3.x  | End of life |
+| 7.2  | 3.x, 4.x | End of life |
+| 7.3  | 3.x, 4.x | End of life |
+| 7.4  | >3.0.33, 4.x, 5.x | Active support |
+| 8.0  | >3.0.33, 4.x, 5.x | Active support |
+| 8.1  | >4.3.0, 5.x | Active support |
 
 * PHP `fileinfo` extension must be present; so make sure this line is active in your php.ini: `extension=php_fileinfo.dll`
 * PHP `iconv` extension must be present; so make sure this line is active in your php.ini: `extension=php_iconv.dll`

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-fileinfo": "*",
         "ext-iconv": "*",
         "ext-imap": "*",


### PR DESCRIPTION
See https://www.php.net/supported-versions.php:

![image](https://user-images.githubusercontent.com/5154682/158021382-929d0ab1-5111-4423-a249-1854b0f4ee5e.png)

Resolves #593.