### PR TITLE
Prevent TypeError while constructing ConnectionException.

### DIFF
--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -709,7 +709,7 @@ final class Imap
         $result = @\imap_open($mailbox, $username, $password, $options, $n_retries, $params);
 
         if (!$result) {
-            throw new ConnectionException(\imap_errors());
+            throw new ConnectionException(\imap_errors() ?: []);
         }
 
         return $result;


### PR DESCRIPTION
Now handles \imap_errors() returning false.
Addresses/avoids barbushin/php-imap#671