### PR TITLE
Fix slash in attachment file name issue

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1348,6 +1348,7 @@ class Mailbox
             $fileName = $this->decodeMimeStr($fileName);
             $fileName = $this->decodeRFC2231($fileName);
         }
+        $fileName = str_replace('/', ' ', $fileName);
 
         /** @var scalar|array|object|null */
         $sizeInBytes = $partStructure->bytes ?? null;


### PR DESCRIPTION
Some systems allow slash(/) in attachment file name, and it causes issue in IncomingMailAttachment::saveToDisk() function. The \file_put_contents() function cannot handle it and throws error
Failed to open stream: No such file or directory