### PR TITLE
Temporary fix for `IMAP\Connection is already closed` #680

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -476,7 +476,12 @@ class Mailbox
 
     public function hasImapStream(): bool
     {
-        return (\is_resource($this->imapStream) || $this->imapStream instanceof \IMAP\Connection) && \imap_ping($this->imapStream);
+        try {
+            return (\is_resource($this->imapStream) || $this->imapStream instanceof \IMAP\Connection) && \imap_ping($this->imapStream);
+        } catch (\ValueError) {
+            // From PHP 8.1.10 imap_ping() on a closed stream throws a ValueError. See #680.
+            return false;
+        }
     }
 
     /**

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -478,7 +478,7 @@ class Mailbox
     {
         try {
             return (\is_resource($this->imapStream) || $this->imapStream instanceof \IMAP\Connection) && \imap_ping($this->imapStream);
-        } catch (\ValueError) {
+        } catch (\ValueError $exception) {
             // From PHP 8.1.10 imap_ping() on a closed stream throws a ValueError. See #680.
             return false;
         }

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -478,9 +478,14 @@ class Mailbox
     {
         try {
             return (\is_resource($this->imapStream) || $this->imapStream instanceof \IMAP\Connection) && \imap_ping($this->imapStream);
-        } catch (\ValueError $exception) {
+        } catch (\Error $exception) {
             // From PHP 8.1.10 imap_ping() on a closed stream throws a ValueError. See #680.
-            return false;
+            $valueError = '\ValueError';
+            if (class_exists($valueError) && $exception instanceof $valueError) {
+                return false;
+            }
+
+            throw $exception;
         }
     }
 


### PR DESCRIPTION
Hello,

This assumes that `\imap_ping` throwing `ValueError: IMAP\Connection is already closed` implies that there's no valid stream, and the library won't try to disconnect an already closed connection. This way the consumer doesn't have to handle this error.

See #680.