### PR TITLE
feat: drop support for php 7.4 and 8.0 (WIP)

### DIFF
--- a/.github/workflows/php_code_coverage.yml
+++ b/.github/workflows/php_code_coverage.yml
@@ -33,7 +33,7 @@ jobs:
         echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/php_code_coverage.yml
+++ b/.github/workflows/php_code_coverage.yml
@@ -22,7 +22,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: xdebug
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -30,10 +30,10 @@ jobs:
     - name: Get Composer Cache Directory
       id: composer-cache
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache Files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/php_static_analysis.yml
+++ b/.github/workflows/php_static_analysis.yml
@@ -33,7 +33,7 @@ jobs:
         echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/php_static_analysis.yml
+++ b/.github/workflows/php_static_analysis.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-20.04']
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.1']
 
     steps:
     - name: Setup PHP
@@ -22,7 +22,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: none
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -30,10 +30,10 @@ jobs:
     - name: Get Composer Cache Directory
       id: composer-cache
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache Files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/php_unit_tests.yml
+++ b/.github/workflows/php_unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-20.04']
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.1', '8.2', '8.3']
 
     steps:
     - name: Setup PHP
@@ -22,7 +22,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: none
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -30,10 +30,10 @@ jobs:
     - name: Get Composer Cache Directory
       id: composer-cache
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache Files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/php_unit_tests.yml
+++ b/.github/workflows/php_unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
         echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache Files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.composer-cache.outputs.dir }}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "ext-iconv": "*",
         "ext-imap": "*",
         "ext-mbstring": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-random": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.38",
@@ -37,17 +38,15 @@
         "paragonie/hidden-string": "^2.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpunit/phpunit": "^10.5.10",
-        "povils/phpmnd": "^3.2",
+        "povils/phpmnd": "^3.4",
         "psalm/plugin-phpunit": "^0.18.4",
-        "roave/security-advisories": "dev-master",
-        "sebastian/phpcpd": "dev-main"
+        "roave/security-advisories": "dev-master"
     },
     "scripts": {
         "static-analysis": [
             "parallel-lint .php-cs-fixer.dist.php src tests examples",
-            "phpcpd src tests",
             "composer-require-checker check --config-file=composer-require-checker.config.json ./composer.json",
-            "phpmnd ./ --exclude=./.github/ --exclude=./examples/ --exclude=./vendor/ --non-zero-exit-on-violation --hint",
+            "phpmnd ./ --exclude=./.github/ --exclude=./examples/ --exclude=./vendor/ --hint",
             "php-cs-fixer fix --allow-risky=yes --no-interaction --dry-run -v",
             "psalm --show-info=false"
         ],

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "nikic/php-parser": "^4.17",
         "paragonie/hidden-string": "^2.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "phpunit/phpunit": "^10.4",
+        "phpunit/phpunit": "^10.5.10",
         "povils/phpmnd": "^3.2",
         "psalm/plugin-phpunit": "^0.18.4",
         "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-fileinfo": "*",
         "ext-iconv": "*",
         "ext-imap": "*",
@@ -31,16 +31,16 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.4",
-        "maglnet/composer-require-checker": "^2.0|^3.2",
-        "nikic/php-parser": "^4.3,<4.7|^4.10",
-        "paragonie/hidden-string": "^1.0",
+        "friendsofphp/php-cs-fixer": "^3.38",
+        "maglnet/composer-require-checker": "^4.7",
+        "nikic/php-parser": "^4.17",
+        "paragonie/hidden-string": "^2.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "phpunit/phpunit": "^8.5|^9.5",
-        "povils/phpmnd": "^2.2",
-        "psalm/plugin-phpunit": "^0.10.0|^0.15.1",
+        "phpunit/phpunit": "^10.4",
+        "povils/phpmnd": "^3.2",
+        "psalm/plugin-phpunit": "^0.18.4",
         "roave/security-advisories": "dev-master",
-        "sebastian/phpcpd": "^4.1|^6.0"
+        "sebastian/phpcpd": "dev-main"
     },
     "scripts": {
         "static-analysis": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,26 +2,19 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     bootstrap="vendor/autoload.php"
-    verbose="true"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     colors="true"
-    forceCoversAnnotation="false"
-    processIsolation="false"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+
+  <source>
     <include>
       <directory>src</directory>
     </include>
-  </coverage>
+  </source>
+
   <testsuites>
     <testsuite name="php-imap Tests">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+
 </phpunit>

--- a/tests/unit/ImapTest.php
+++ b/tests/unit/ImapTest.php
@@ -37,7 +37,7 @@ class ImapTest extends Base
     /**
      * @psalm-return Generator<'CI ENV with invalid password'|'empty mailbox/username/password', array{0: ConnectionException::class, 1: '/^[AUTHENTICATIONFAILED]/'|'Can't open mailbox : no such mailbox', 2: array{0: HiddenString, 1: HiddenString, 2: HiddenString, 3: 0, 4: 0, 5: array<empty, empty>}, 3?: true}, mixed, void>
      */
-    public function OpenFailure(): Generator
+    public static function OpenFailure(): Generator
     {
         yield 'empty mailbox/username/password' => [
             ConnectionException::class,

--- a/tests/unit/Issue519Test.php
+++ b/tests/unit/Issue519Test.php
@@ -107,7 +107,7 @@ class Issue519Test extends TestCase
      *
      * @return string[][]
      */
-    public function provider(): array
+    public static function provider(): array
     {
         $out = [];
 

--- a/tests/unit/LiveMailboxStringDecodingConvertingTest.php
+++ b/tests/unit/LiveMailboxStringDecodingConvertingTest.php
@@ -19,7 +19,7 @@ class LiveMailboxStringDecodingConvertingTest extends TestCase
     /**
      * Provides data for testing string decoding.
      */
-    public function stringDecodeProvider(): Generator
+    public static function stringDecodeProvider(): Generator
     {
         yield 'Issue #250 iso-8859-1' => [
             ENCQUOTEDPRINTABLE,

--- a/tests/unit/LiveMailboxTestingTrait.php
+++ b/tests/unit/LiveMailboxTestingTrait.php
@@ -30,7 +30,7 @@ trait LiveMailboxTestingTrait
      *
      * @return (\ParagonIE\HiddenString\HiddenString|string)[][]
      */
-    public function MailBoxProvider(): array
+    public static function MailBoxProvider(): array
     {
         $sets = [];
 

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -96,7 +96,7 @@ final class MailboxTest extends TestCase
      *
      * @return string[][]
      */
-    public function SetAndGetServerEncodingProvider(): array
+    public static function SetAndGetServerEncodingProvider(): array
     {
         $data = [
             ['UTF-8'],
@@ -168,7 +168,7 @@ final class MailboxTest extends TestCase
      *
      * @psalm-return array{UTF-7: array{0: true, 1: 'UTF-7'}, UTF7-IMAP: array{0: true, 1: 'UTF7-IMAP'}, UTF-8: array{0: true, 1: 'UTF-8'}, ASCII: array{0: true, 1: 'ASCII'}, US-ASCII: array{0: true, 1: 'US-ASCII'}, ISO-8859-1: array{0: true, 1: 'ISO-8859-1'}, UTF7: array{0: false, 1: 'UTF7'}, UTF-7-IMAP: array{0: false, 1: 'UTF-7-IMAP'}, UTF-7IMAP: array{0: false, 1: 'UTF-7IMAP'}, UTF8: array{0: false, 1: 'UTF8'}, USASCII: array{0: false, 1: 'USASCII'}, ASC11: array{0: false, 1: 'ASC11'}, ISO-8859-0: array{0: false, 1: 'ISO-8859-0'}, ISO-8855-1: array{0: false, 1: 'ISO-8855-1'}, ISO-8859: array{0: false, 1: 'ISO-8859'}}
      */
-    public function serverEncodingProvider(): array
+    public static function serverEncodingProvider(): array
     {
         return [
             // Supported encodings
@@ -262,7 +262,7 @@ final class MailboxTest extends TestCase
      *
      * @return string[][]
      */
-    public function pathDelimiterProvider(): array
+    public static function pathDelimiterProvider(): array
     {
         return [
             '0' => ['0'],
@@ -372,7 +372,7 @@ final class MailboxTest extends TestCase
      *
      * @psalm-return array<string, array{0:bool}>
      */
-    public function attachmentsIgnoreProvider(): array
+    public static function attachmentsIgnoreProvider(): array
     {
         /** @psalm-var array<string, array{0:bool}> */
         return [
@@ -400,7 +400,7 @@ final class MailboxTest extends TestCase
      *
      * @return string[][]
      */
-    public function encodingTestStringsProvider(): array
+    public static function encodingTestStringsProvider(): array
     {
         return [
             'Avañe’ẽ' => ['Avañe’ẽ'], // Guaraní
@@ -468,7 +468,7 @@ final class MailboxTest extends TestCase
      *
      * @return (int|string)[][]
      */
-    public function datetimeProvider(): array
+    public static function datetimeProvider(): array
     {
         return [
             'Sun, 14 Aug 2005 16:13:03 +0000 (CEST)' => ['2005-08-14T16:13:03+00:00', 1124035983],
@@ -507,7 +507,7 @@ final class MailboxTest extends TestCase
      *
      * @return string[][]
      */
-    public function invalidDatetimeProvider(): array
+    public static function invalidDatetimeProvider(): array
     {
         return [
             'Sun, 14 Aug 2005 16:13:03 +9000 (CEST)' => ['Sun, 14 Aug 2005 16:13:03 +9000 (CEST)'],
@@ -543,7 +543,7 @@ final class MailboxTest extends TestCase
      *
      * @psalm-return array{0: array{0: '=?iso-8859-1?Q?Sebastian_Kr=E4tzig?= <sebastian.kraetzig@example.com>', 1: 'Sebastian Krätzig <sebastian.kraetzig@example.com>'}, 1: array{0: '=?iso-8859-1?Q?Sebastian_Kr=E4tzig?=', 1: 'Sebastian Krätzig'}, 2: array{0: 'sebastian.kraetzig', 1: 'sebastian.kraetzig'}, 3: array{0: '=?US-ASCII?Q?Keith_Moore?= <km@ab.example.edu>', 1: 'Keith Moore <km@ab.example.edu>'}, 4: array{0: '   ', 1: '   '}, 5: array{0: '=?ISO-8859-1?Q?Max_J=F8rn_Simsen?= <max.joern.s@example.dk>', 1: 'Max Jørn Simsen <max.joern.s@example.dk>'}, 6: array{0: '=?ISO-8859-1?Q?Andr=E9?= Muster <andre.muster@vm1.ulg.ac.be>', 1: 'André Muster <andre.muster@vm1.ulg.ac.be>'}, 7: array{0: '=?ISO-8859-1?B?SWYgeW91IGNhbiByZWFkIHRoaXMgeW8=?= =?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=', 1: 'If you can read this you understand the example.'}, 8: array{0: '', 1: ''}}
      */
-    public function mimeEncodingProvider(): array
+    public static function mimeEncodingProvider(): array
     {
         return [
             ['=?iso-8859-1?Q?Sebastian_Kr=E4tzig?= <sebastian.kraetzig@example.com>', 'Sebastian Krätzig <sebastian.kraetzig@example.com>'],
@@ -575,7 +575,7 @@ final class MailboxTest extends TestCase
      *
      * @psalm-return array<string, array{0:'assertNull'|'expectException', 1:int, 2:list<1|2|3|4>}>
      */
-    public function timeoutsProvider(): array
+    public static function timeoutsProvider(): array
     {
         /** @psalm-var array<string, array{0:'assertNull'|'expectException', 1:int, 2:list<int>}> */
         return [
@@ -614,7 +614,7 @@ final class MailboxTest extends TestCase
      *
      * @psalm-return Generator<string, array{0: 'assertNull'|'expectException', 1: int, 2: 0, 3: array<empty, empty>}, mixed, void>
      */
-    public function connectionArgsProvider(): Generator
+    public static function connectionArgsProvider(): Generator
     {
         yield from [
             'readonly, disable gssapi' => ['assertNull', OP_READONLY, 0, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']],
@@ -700,7 +700,7 @@ final class MailboxTest extends TestCase
      *
      * @return string[][]
      */
-    public function mimeStrDecodingProvider(): array
+    public static function mimeStrDecodingProvider(): array
     {
         return [
             '<bde36ec8-9710-47bc-9ea3-bf0425078e33@php.imap>' => ['<bde36ec8-9710-47bc-9ea3-bf0425078e33@php.imap>', '<bde36ec8-9710-47bc-9ea3-bf0425078e33@php.imap>'],
@@ -737,7 +737,7 @@ final class MailboxTest extends TestCase
      *
      * @return string[][]
      */
-    public function Base64DecodeProvider(): array
+    public static function Base64DecodeProvider(): array
     {
         return [
             ['bm8tcmVwbHlAZXhhbXBsZS5jb20=', 'no-reply@example.com'],
@@ -764,7 +764,7 @@ final class MailboxTest extends TestCase
      *
      * @return string[][]
      */
-    public function attachmentDirFailureProvider(): array
+    public static function attachmentDirFailureProvider(): array
     {
         return [
             [


### PR DESCRIPTION
bump dev dependencies,
fix ci deprecations,
migrate to PHPUnit 10

PHP 8 will be EOL at the end of november 2023.
https://www.php.net/supported-versions.php


PHPUnit 10 wants to have DataProvider to be static.
There are some DataProviders left that can not be changed that easy.