### PR TITLE
Update syntax to php8.4

### DIFF
--- a/src/PhpImap/Exceptions/ConnectionException.php
+++ b/src/PhpImap/Exceptions/ConnectionException.php
@@ -13,7 +13,7 @@ use Exception;
  */
 class ConnectionException extends Exception
 {
-    public function __construct(array $message, int $code = 0, Exception $previous = null)
+    public function __construct(array $message, int $code = 0, ?Exception $previous = null)
     {
         parent::__construct(json_encode($message), $code, $previous);
     }

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -79,8 +79,8 @@ final class Imap
         $imap_stream,
         string $mailbox,
         string $message,
-        string $options = null,
-        string $internal_date = null
+        ?string $options = null,
+        ?string $internal_date = null
     ): bool {
         \imap_errors(); // flush errors
 
@@ -816,7 +816,7 @@ final class Imap
         $imap_stream,
         string $criteria,
         int $options = SE_FREE,
-        string $charset = null,
+        ?string $charset = null,
         bool $encodeCriteriaAsUtf7Imap = false
     ): array {
         \imap_errors(); // flush errors
@@ -906,8 +906,8 @@ final class Imap
         int $criteria,
         bool $reverse,
         int $options,
-        string $search_criteria = null,
-        string $charset = null
+        ?string $search_criteria = null,
+        ?string $charset = null
     ): array {
         \imap_errors(); // flush errors
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -165,7 +165,7 @@ class Mailbox
     /**
      * @throws InvalidParameterException
      */
-    public function __construct(string $imapPath, string $login, string $password, string $attachmentsDir = null, string $serverEncoding = 'UTF-8', bool $trimImapPath = true, bool $attachmentFilenameMode = false)
+    public function __construct(string $imapPath, string $login, string $password, ?string $attachmentsDir = null, string $serverEncoding = 'UTF-8', bool $trimImapPath = true, bool $attachmentFilenameMode = false)
     {
         $this->imapPath = (true == $trimImapPath) ? \trim($imapPath) : $imapPath;
         $this->imapLogin = \trim($login);
@@ -380,7 +380,7 @@ class Mailbox
      *
      * @throws InvalidParameterException
      */
-    public function setConnectionArgs(int $options = 0, int $retriesNum = 0, array $params = null): void
+    public function setConnectionArgs(int $options = 0, int $retriesNum = 0, array ?$params = null): void
     {
         if (0 !== $options) {
             if (($options & self::IMAP_OPTIONS_SUPPORTED_VALUES) !== $options) {
@@ -1020,7 +1020,7 @@ class Mailbox
         int $criteria = SORTARRIVAL,
         bool $reverse = true,
         ?string $searchCriteria = 'ALL',
-        string $charset = null
+        ?string $charset = null
     ): array {
         return Imap::sort(
             $this->getImapStream(),
@@ -1634,8 +1634,8 @@ class Mailbox
     public function appendMessageToMailbox(
         $message,
         string $mailbox = '',
-        string $options = null,
-        string $internal_date = null
+        ?string $options = null,
+        ?string $internal_date = null
     ): bool {
         if (
             \is_array($message) &&

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -380,7 +380,7 @@ class Mailbox
      *
      * @throws InvalidParameterException
      */
-    public function setConnectionArgs(int $options = 0, int $retriesNum = 0, array ?$params = null): void
+    public function setConnectionArgs(int $options = 0, int $retriesNum = 0, ?array $params = null): void
     {
         if (0 !== $options) {
             if (($options & self::IMAP_OPTIONS_SUPPORTED_VALUES) !== $options) {

--- a/tests/unit/Fixtures/DataPartInfo.php
+++ b/tests/unit/Fixtures/DataPartInfo.php
@@ -16,7 +16,7 @@ class DataPartInfo extends Base
         return $this->decodeAfterFetch($this->data);
     }
 
-    public function setData(string $data = null): void
+    public function setData(?string $data = null): void
     {
         $this->data = $data;
     }

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -678,7 +678,7 @@ final class MailboxTest extends TestCase
      *
      * @psalm-param array{DISABLE_AUTHENTICATOR?:string}|array<empty, empty> $param
      */
-    public function testSetConnectionArgs(string $assertMethod, int $option, int $retriesNum, array $param = null): void
+    public function testSetConnectionArgs(string $assertMethod, int $option, int $retriesNum, ?array $param = null): void
     {
         $mailbox = $this->getMailbox();
 


### PR DESCRIPTION
Fix warnings like "Implicitly marking parameter $attachmentsDir as nullable is deprecated"