### PR TITLE
method decodeStringFromUtf7ImapToUtf8() returns UTF-8 instead of ISO-8859-1

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -510,7 +510,7 @@ class Mailbox
      */
     public function decodeStringFromUtf7ImapToUtf8(string $str): string
     {
-        $out = imap_utf7_decode($str);
+        $out = mb_convert_encoding($str, 'UTF-8', 'UTF7-IMAP');
 
         if (!\is_string($out)) {
             throw new UnexpectedValueException('mb_convert_encoding($str, \'UTF-8\', \'UTF7-IMAP\') could not convert $str');


### PR DESCRIPTION
The imap_utf7_decode() method used previously returns ISO-8859-1, which makes the searchMailbox() method call useless.