### PR TITLE
Allow typed arguments to be null

### DIFF
--- a/src/PhpImap/Exceptions/ConnectionException.php
+++ b/src/PhpImap/Exceptions/ConnectionException.php
@@ -13,7 +13,7 @@ use Exception;
  */
 class ConnectionException extends Exception
 {
-    public function __construct(array $message, int $code = 0, Exception $previous = null)
+    public function __construct(array $message, int $code = 0, ?Exception $previous = null)
     {
         parent::__construct(json_encode($message), $code, $previous);
     }

--- a/src/PhpImap/Imap.php
+++ b/src/PhpImap/Imap.php
@@ -79,8 +79,8 @@ final class Imap
         $imap_stream,
         string $mailbox,
         string $message,
-        string $options = null,
-        string $internal_date = null
+        ?string $options = null,
+        ?string $internal_date = null
     ): bool {
         \imap_errors(); // flush errors
 
@@ -816,7 +816,7 @@ final class Imap
         $imap_stream,
         string $criteria,
         int $options = SE_FREE,
-        string $charset = null,
+        ?string $charset = null,
         bool $encodeCriteriaAsUtf7Imap = false
     ): array {
         \imap_errors(); // flush errors
@@ -906,8 +906,8 @@ final class Imap
         int $criteria,
         bool $reverse,
         int $options,
-        string $search_criteria = null,
-        string $charset = null
+        ?string $search_criteria = null,
+        ?string $charset = null
     ): array {
         \imap_errors(); // flush errors
 

--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -165,7 +165,7 @@ class Mailbox
     /**
      * @throws InvalidParameterException
      */
-    public function __construct(string $imapPath, string $login, string $password, string $attachmentsDir = null, string $serverEncoding = 'UTF-8', bool $trimImapPath = true, bool $attachmentFilenameMode = false)
+    public function __construct(string $imapPath, string $login, string $password, ?string $attachmentsDir = null, string $serverEncoding = 'UTF-8', bool $trimImapPath = true, bool $attachmentFilenameMode = false)
     {
         $this->imapPath = (true == $trimImapPath) ? \trim($imapPath) : $imapPath;
         $this->imapLogin = \trim($login);
@@ -380,7 +380,7 @@ class Mailbox
      *
      * @throws InvalidParameterException
      */
-    public function setConnectionArgs(int $options = 0, int $retriesNum = 0, array $params = null): void
+    public function setConnectionArgs(int $options = 0, int $retriesNum = 0, ?array $params = null): void
     {
         if (0 !== $options) {
             if (($options & self::IMAP_OPTIONS_SUPPORTED_VALUES) !== $options) {
@@ -1020,7 +1020,7 @@ class Mailbox
         int $criteria = SORTARRIVAL,
         bool $reverse = true,
         ?string $searchCriteria = 'ALL',
-        string $charset = null
+        ?string $charset = null
     ): array {
         return Imap::sort(
             $this->getImapStream(),
@@ -1634,8 +1634,8 @@ class Mailbox
     public function appendMessageToMailbox(
         $message,
         string $mailbox = '',
-        string $options = null,
-        string $internal_date = null
+        ?string $options = null,
+        ?string $internal_date = null
     ): bool {
         if (
             \is_array($message) &&


### PR DESCRIPTION
This change is to resolve deprecation warnings in PHP 8.4 like this:

"Deprecated: PhpImap\\Imap::append(): Implicitly marking parameter $internal_date as nullable is deprecated, the explicit nullable type must be used instead"