### PR TITLE
Extend unit tests and fix decoding bug

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1966,9 +1966,8 @@ class Mailbox
     {
         if (\preg_match("/^(.*?)'.*?'(.*?)$/", $string, $matches)) {
             $data = $matches[2] ?? '';
-            if ($this->isUrlEncoded($data)) {
-                $string = $this->decodeMimeStr(\urldecode($data));
-            }
+            $decodedData = $this->isUrlEncoded($data) ? \urldecode($data) : $data;
+            $string = $this->decodeMimeStr($decodedData);
         }
 
         return $string;

--- a/tests/unit/Fixtures/Mailbox.php
+++ b/tests/unit/Fixtures/Mailbox.php
@@ -8,6 +8,11 @@ use PhpImap\Mailbox as Base;
 
 class Mailbox extends Base
 {
+    public function decodeRFC2231ForTests(string $string): string
+    {
+        return $this->decodeRFC2231($string);
+    }
+
     public function getImapPassword(): string
     {
         return $this->imapPassword;

--- a/tests/unit/LiveMailboxStringDecodingConvertingTest.php
+++ b/tests/unit/LiveMailboxStringDecodingConvertingTest.php
@@ -61,6 +61,22 @@ class LiveMailboxStringDecodingConvertingTest extends TestCase
             'a05e42c7e14de716cd501e135f3f5e49545f71069de316a1e9f7bb153f9a7356',
         ];
 
+        yield 'Windows-1251 quoted-printable' => [
+            ENCQUOTEDPRINTABLE,
+            'windows-1251',
+            '=CF=F0=E8=E2=E5=F2 =EC=E8=F0',
+            'Привет мир',
+            '830d1964dc8673182a40f9adebf598960d37fbe200405b249774ecfa5b465748',
+        ];
+
+        yield 'CP1252 quoted-printable via iconv alias fallback' => [
+            ENCQUOTEDPRINTABLE,
+            'cp1252',
+            'Price =8010',
+            'Price €10',
+            'eeccbb8eb0acf81c5750271d1a9fd7e0bfb4f3309eae8b4ff07e4acf33e947b9',
+        ];
+
         yield 'Emoji utf-8' => [
             ENCQUOTEDPRINTABLE,
             'utf-8',

--- a/tests/unit/MailboxEncodingTest.php
+++ b/tests/unit/MailboxEncodingTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Mailbox encoding focused unit tests.
+ */
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use PHPUnit\Framework\TestCase;
+
+final class MailboxEncodingTest extends TestCase
+{
+    /**
+     * @return array<string, array{0:string, 1:string, 2:string, 3?:string}>
+     */
+    public function convertToUtf8Provider(): array
+    {
+        return [
+            'default charset uses configured alias' => [
+                "Price \x8010",
+                'default',
+                'Price €10',
+                'cp1252',
+            ],
+            'iconv alias fallback' => [
+                "Price \x8010",
+                'cp1252',
+                'Price €10',
+            ],
+            'unknown charset returns original bytes' => [
+                "caf\xe9",
+                'x-unknown-charset',
+                "caf\xe9",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider convertToUtf8Provider
+     */
+    public function testConvertToUtf8(string $input, string $charset, string $expected, string $defaultCharset = 'default'): void
+    {
+        $mailbox = new Fixtures\Mailbox('', '', '');
+        $mailbox->decodeMimeStrDefaultCharset = $defaultCharset;
+
+        $this->assertSame($expected, $mailbox->convertToUtf8($input, $charset));
+    }
+
+    /**
+     * @return array<string, array{0:string, 1:bool}>
+     */
+    public function isUrlEncodedProvider(): array
+    {
+        return [
+            'RFC2231 encoded segment' => ['%E2%82%AC%20rates.txt', true],
+            'encoded mime-word' => ['%3D%3FUTF-8%3FQ%3Fmountainguan%3DE6%3DB5%3D8B%3DE8%3DAF%3D95%3F%3D', true],
+            'plain ascii' => ['plain-file.txt', false],
+            'invalid percent escape' => ['%ZZrates.txt', false],
+        ];
+    }
+
+    /**
+     * @dataProvider isUrlEncodedProvider
+     */
+    public function testIsUrlEncoded(string $input, bool $expected): void
+    {
+        $this->assertSame($expected, (new Fixtures\Mailbox('', '', ''))->isUrlEncoded($input));
+    }
+
+    /**
+     * @return array<string, array{0:string, 1:string}>
+     */
+    public function decodeRFC2231Provider(): array
+    {
+        return [
+            'plain ascii filename strips RFC2231 metadata' => [
+                "utf-8''plain-file.txt",
+                'plain-file.txt',
+            ],
+            'utf-8 filename with language tag' => [
+                "utf-8'de'%E2%82%AC%20rates.txt",
+                '€ rates.txt',
+            ],
+            'url-encoded mime encoded-word' => [
+                "utf-8'en'%3D%3FUTF-8%3FQ%3Fmountainguan%3DE6%3DB5%3D8B%3DE8%3DAF%3D95%3F%3D",
+                'mountainguan测试',
+            ],
+            'non RFC2231 string is unchanged' => [
+                'plain-file.txt',
+                'plain-file.txt',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider decodeRFC2231Provider
+     */
+    public function testDecodeRFC2231(string $input, string $expected): void
+    {
+        $mailbox = new Fixtures\Mailbox('', '', '');
+
+        $this->assertSame($expected, $mailbox->decodeRFC2231ForTests($input));
+    }
+}


### PR DESCRIPTION
Increased coverage around the encoding/conversion paths and fixed one real decoding bug. `src/PhpImap/Mailbox.php:1965` now always strips RFC2231 charset'lang' metadata and decodes the value, even when the filename is plain ASCII instead of percent-encoded. I added focused tests in `tests/unit/MailboxEncodingTest.php:11` for `convertToUtf8`, `isUrlEncoded`, and RFC2231 decoding, exposed the protected helper through `tests/unit/Fixtures/Mailbox.php:11`, and extended `tests/unit/ LiveMailboxStringDecodingConvertingTest.php:22` with `windows-1251` and `cp1252` quoted-printable cases.