### PR TITLE
Fix broken decodeStringFromUtf7ImapToUtf8() function

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -583,13 +583,7 @@ class Mailbox
      */
     public function decodeStringFromUtf7ImapToUtf8(string $str): string
     {
-        $out = imap_utf7_decode($str);
-
-        if (!\is_string($out)) {
-            throw new UnexpectedValueException('mb_convert_encoding($str, \'UTF-8\', \'UTF7-IMAP\') could not convert $str');
-        }
-
-        return $out;
+        return Imap::decodeStringFromUtf7ImapToUtf8($str);
     }
 
     /**

--- a/tests/unit/MailboxEncodingTest.php
+++ b/tests/unit/MailboxEncodingTest.php
@@ -101,4 +101,15 @@ final class MailboxEncodingTest extends TestCase
 
         $this->assertSame($expected, $mailbox->decodeRFC2231ForTests($input));
     }
+
+    public function testDecodeStringFromUtf7ImapToUtf8DecodesMailboxNamesToUtf8(): void
+    {
+        $mailbox = new Fixtures\Mailbox('', '', '');
+        $encodedMailboxName = '{imap.example.com:993/imap/ssl}INBOX.&bUuL1Q-';
+
+        $this->assertSame(
+            '{imap.example.com:993/imap/ssl}INBOX.测试',
+            $mailbox->decodeStringFromUtf7ImapToUtf8($encodedMailboxName)
+        );
+    }
 }


### PR DESCRIPTION
- `src/PhpImap/Mailbox.php:584` now delegates to the existing `src/PhpImap/Imap.php:1072` implementation, so Mailbox no longer has its own divergent `imap_utf7_decode()` path.
- Add respective unit tests

Superseeds #736 