### PR TITLE
Fix flattenParts() for PARTY_TYPE_TWO

### DIFF
--- a/src/PhpImap/Mailbox.php
+++ b/src/PhpImap/Mailbox.php
@@ -1387,7 +1387,7 @@ class Mailbox
                 $part_parts = $part->parts;
 
                 if (self::PART_TYPE_TWO == $part->type) {
-                    $flattenedParts = $this->flattenParts($part_parts, $flattenedParts, $prefix.$index.'.', 0, false);
+                    $flattenedParts = $this->flattenParts($part_parts, $flattenedParts, $prefix.$index.'.', 1, false);
                 } elseif ($fullPrefix) {
                     $flattenedParts = $this->flattenParts($part_parts, $flattenedParts, $prefix.$index.'.');
                 } else {

--- a/tests/unit/MailboxTest.php
+++ b/tests/unit/MailboxTest.php
@@ -210,6 +210,33 @@ final class MailboxTest extends TestCase
         }
     }
 
+    public function testFlattenPartsStartsRfc822SubPartsWithOne(): void
+    {
+        $plainTextPart = (object) [
+            'type' => TYPETEXT,
+            'subtype' => 'PLAIN',
+        ];
+        $htmlPart = (object) [
+            'type' => TYPETEXT,
+            'subtype' => 'HTML',
+        ];
+        $multipartAlternative = (object) [
+            'type' => TYPEMULTIPART,
+            'subtype' => 'ALTERNATIVE',
+            'parts' => [$plainTextPart, $htmlPart],
+        ];
+        $rfc822Part = (object) [
+            'type' => Mailbox::PART_TYPE_TWO,
+            'subtype' => 'RFC822',
+            'parts' => [$multipartAlternative],
+        ];
+
+        $flattenedParts = $this->getMailbox()->flattenParts([$rfc822Part]);
+
+        $this->assertSame(['1', '1.1', '1.2'], \array_keys($flattenedParts));
+        $this->assertArrayNotHasKey('1.0', $flattenedParts);
+    }
+
     /**
      * Test, that the IMAP search option has a default value
      * 1 => SE_UID


### PR DESCRIPTION
This change should fix all kinds of weird attachment related bugs as stated by the original author of this change.

- Fix incorrect sub-part index
- Add respective unit tests

Co-authored by @mathielen

Refs:
- https://github.com/barbushin/php-imap/pull/723

Superseeds #723 