### PR TITLE
Fix boolean received error in getFileInfo()

### DIFF
--- a/src/PhpImap/IncomingMailAttachment.php
+++ b/src/PhpImap/IncomingMailAttachment.php
@@ -131,9 +131,23 @@ class IncomingMailAttachment
      */
     public function getFileInfo(int $fileinfo_const = FILEINFO_NONE): string
     {
+        $fileInfo = $this->detectFileInfo($fileinfo_const, $this->getContents());
+
+        if (false === $fileInfo) {
+            return '';
+        }
+
+        return $fileInfo;
+    }
+
+    /**
+     * @return false|string
+     */
+    protected function detectFileInfo(int $fileinfo_const, string $contents)
+    {
         $finfo = new finfo($fileinfo_const);
 
-        return $finfo->buffer($this->getContents());
+        return $finfo->buffer($contents);
     }
 
     /**

--- a/tests/unit/IncomingMailAttachmentTest.php
+++ b/tests/unit/IncomingMailAttachmentTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpImap;
+
+use const FILEINFO_MIME_TYPE;
+
+use PHPUnit\Framework\TestCase;
+
+final class IncomingMailAttachmentTest extends TestCase
+{
+    public function testGetFileInfoReturnsEmptyStringWhenFinfoBufferFails(): void
+    {
+        $attachment = new class() extends IncomingMailAttachment {
+            public function getContents(): string
+            {
+                return 'broken-image-contents';
+            }
+
+            protected function detectFileInfo(int $fileinfo_const, string $contents)
+            {
+                return false;
+            }
+        };
+
+        $this->assertSame('', $attachment->getFileInfo(FILEINFO_MIME_TYPE));
+    }
+
+    public function testGetFileInfoReturnsDetectedStringWhenFinfoBufferSucceeds(): void
+    {
+        $attachment = new class() extends IncomingMailAttachment {
+            public function getContents(): string
+            {
+                return 'png-contents';
+            }
+
+            protected function detectFileInfo(int $fileinfo_const, string $contents)
+            {
+                return 'image/png';
+            }
+        };
+
+        $this->assertSame('image/png', $attachment->getFileInfo(FILEINFO_MIME_TYPE));
+    }
+}


### PR DESCRIPTION
The change is in `src/PhpImap/IncomingMailAttachment.php:132: getFileInfo()` now routes the finfo lookup through a small helper and returns `''` if detection fails instead of propagating false into a string return type. I also added `tests/unit/IncomingMailAttachmentTest.php:1` with one regression test for the failure branch and one sanity check for the normal branch.

Solves #734 