### PR TITLE
#710 - fix embeding images with multiple inline images

### DIFF
--- a/src/PhpImap/IncomingMail.php
+++ b/src/PhpImap/IncomingMail.php
@@ -220,11 +220,8 @@ class IncomingMail extends IncomingMailHeader
                 $cid = \str_replace('cid:', '', $match);
 
                 foreach ($attachments as $attachment) {
-                    /**
-                     * Inline images can contain a "Content-Disposition: inline", but only a "Content-ID" is also enough.
-                     * See https://github.com/barbushin/php-imap/issues/569.
-                     */
-                    if ($attachment->contentId == $cid || 'inline' == \mb_strtolower((string) $attachment->disposition)) {
+                    
+                    if ($attachment->contentId == $cid) {
                         $contents = $attachment->getContents();
                         $contentType = $attachment->getFileInfo(FILEINFO_MIME_TYPE);
 


### PR DESCRIPTION
reposting request: https://github.com/bpali/php-imap/pull/1

after #580  ($contentId || 'inline') replaces every inline image within an email with the first one found. So fix #580  is invalid for that case.


Also a question if checking disposition is really necessary? If it is then i'd propose code below

```php
$contentMatch = $attachment->contentId == $cid;
if ($attachment->disposition && !empty($attachment->disposition)) {
    $contentMatch &= 'inline' == \mb_strtolower((string) $attachment->disposition);
}

if ($contentMatch) {
//convert to base64 
```

<img width="761" height="587" alt="image" src="https://github.com/user-attachments/assets/a4e2d060-e867-440f-bf1f-aabd3b3dd600" />
